### PR TITLE
Королева больше не откроет эвак под без эвака.

### DIFF
--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Content.Shared._RMC14.Evacuation;
 using Content.Shared._RMC14.Prying;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
@@ -98,6 +99,9 @@ public sealed class PryingSystem : EntitySystem
             // If we have reached this point we want the event that caused this
             // to be marked as handled.
             return true;
+
+        if (TryComp<EvacuationDoorComponent>(target, out var state) && state.Locked) //Stories-Fix
+            return false; //Stories-Fix
 
         if (HasComp<RMCUserPryingRequiresToolComponent>(user))
         {


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
<!-- Ниже опишите ваш Pull Request. Что он изменяет? На что еще это может повлиять? Постарайтесь описать все внесённые вами изменения! -->
СМ Название ПРа, эвак двери больше не открыть пока не объявлен эвак.


**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт. -->

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят.

В журнал изменений следует помещать только то, что действительно важно игрокам.

В списке изменений тип значка не является часть предложения, поэтому явно указывайте - Добавлен, Удалён, Изменён.
плохо: - add: Новый инструмент для инженеров
хорошо: - add: Добавлен новый инструмент для инженеров

Вы можете указать своё имя после символа :cl: именно оно будет отображаться в журнале изменений (иначе будет использоваться ваше имя на GitHub)
Например: :cl: Ian

-->

:cl:
- fix: Королева больше не открывает под эвака без эвака.
