### PR TITLE
Фиксы спрайтов

### DIFF
--- a/Content.Client/_RMC14/TacticalMap/TacticalMapWindow.xaml
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapWindow.xaml
@@ -1,6 +1,6 @@
 ﻿<controls:TacticalMapWindow
     xmlns="https://spacestation14.io"
     xmlns:controls="clr-namespace:Content.Client._RMC14.TacticalMap"
-    Title="Map" SetSize="600 600">
+    Title="Map" SetSize="1000 800">
     <controls:TacticalMapWrapper Name="Wrapper" Access="Public" />
 </controls:TacticalMapWindow>

--- a/Content.Client/_RMC14/TacticalMap/TacticalMapWindow.xaml
+++ b/Content.Client/_RMC14/TacticalMap/TacticalMapWindow.xaml
@@ -1,6 +1,6 @@
 ﻿<controls:TacticalMapWindow
     xmlns="https://spacestation14.io"
     xmlns:controls="clr-namespace:Content.Client._RMC14.TacticalMap"
-    Title="Map" SetSize="1000 800">
+    Title="Map" SetSize="600 600">
     <controls:TacticalMapWrapper Name="Wrapper" Access="Public" />
 </controls:TacticalMapWindow>

--- a/Content.Shared/_Stories/Xenonids/XenoBoxer/BoxerJab/BoxerJabSystem.cs
+++ b/Content.Shared/_Stories/Xenonids/XenoBoxer/BoxerJab/BoxerJabSystem.cs
@@ -34,10 +34,10 @@ public sealed class BoxerJabSystem : EntitySystem
         if (args.Handled)
             return;
 
-        args.Handled = true;
-
         if (!_xeno.CanAbilityAttackTarget(xeno, args.Target))
             return;
+
+        args.Handled = true;
 
         if (!TryComp<XenoBoxerKnockoutComponent>(xeno, out var knockoutComp))
             return;

--- a/Content.Shared/_Stories/Xenonids/XenoBoxer/BoxerPunch/BoxerPunchSystem.cs
+++ b/Content.Shared/_Stories/Xenonids/XenoBoxer/BoxerPunch/BoxerPunchSystem.cs
@@ -37,13 +37,13 @@ public sealed class BoxerPunchSystem : EntitySystem
         if (args.Handled)
             return;
 
-        args.Handled = true;
-
         var comp = xeno.Comp;
         var targetUid = args.Target;
 
         if (!_xeno.CanAbilityAttackTarget(xeno, targetUid))
             return;
+
+        args.Handled = true;
 
         if (!TryComp<XenoBoxerKnockoutComponent>(xeno, out var knockoutComp))
             return;

--- a/Content.Shared/_Stories/Xenonids/XenoBoxer/BoxerUppercut/BoxerUppercutSystem.cs
+++ b/Content.Shared/_Stories/Xenonids/XenoBoxer/BoxerUppercut/BoxerUppercutSystem.cs
@@ -55,14 +55,14 @@ public sealed class BoxerUppercutSystem : EntitySystem
         if (args.Handled)
             return;
 
-        args.Handled = true;
-
         var targetUid = args.Target;
         var comp = xeno.Comp;
         var popupPower = "weak";
 
         if (!_xeno.CanAbilityAttackTarget(xeno, targetUid))
             return;
+
+        args.Handled = true;
 
         if (!TryComp(xeno, out XenoBoxerKnockoutComponent? knockoutComp) ||
             !TryComp(xeno, out XenoBoxerKnockoutRecentlyComponent? recently))
@@ -111,6 +111,7 @@ public sealed class BoxerUppercutSystem : EntitySystem
         {
             _throwing.TryThrow(targetUid, diff, 10);
             _stun.TryParalyze(targetUid, comp.ParalyzeTime, true);
+            _stun.TrySlowdown(targetUid, comp.ParalyzeTime * 2, true);
             popupPower = "gigantic";
         }
         else

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/parasite_prop.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/parasite_prop.yml
@@ -10,5 +10,5 @@
     bodyType: Static
     canCollide: false
   - type: Sprite
-    sprite:  _RMC14/Mobs/Xenonids/Parasite/parasite.rsi
+    sprite:  _Stories/Mobs/Xenos/Parasite/parasite.rsi
     state: impregnated

--- a/Resources/Prototypes/_RMC14/Roles/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Xeno/queen.yml
@@ -31,7 +31,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
-    sprite: _RMC14/Mobs/Xenonids/Queen/queen.rsi
+    sprite: _Stories/Mobs/Xenos/Queen/queen.rsi
     layers:
     - state: alive
       scale: 0.5, 0.5

--- a/Resources/Prototypes/_RMC14/Roles/Xeno/selectable.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Xeno/selectable.yml
@@ -15,7 +15,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
-    sprite: _RMC14/Mobs/Xenonids/Larva/larva.rsi
+    sprite: _Stories/Mobs/Xenos/Larva/larva.rsi
     layers:
     - state: alive
       scale: 0.5, 0.5


### PR DESCRIPTION
Заменены спрайты королевы и личинок в лобби на наши. Это также относится к лицехвату-пропу на картах
Вернул старый начальный размер карты, иначе это неудобно
Снова фикс обработки способностей боксера. Теперь в этом пре мб замерджишь быстрее =)))))))))))

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
