### PR TITLE
rmc shitcode remove 🚯

### DIFF
--- a/Content.Server/_RMC14/Marines/Squads/SquadCommand.cs
+++ b/Content.Server/_RMC14/Marines/Squads/SquadCommand.cs
@@ -33,9 +33,10 @@ public sealed class SquadCommand : ToolshedCommand
         [PipedArgument] EntityUid marine,
         [CommandArgument] Entity<SquadTeamComponent> squad)
     {
+        /* Stories-Shit-Fix
         if (!HasComp<MarineComponent>(marine))
             return marine;
-
+        */
         _squad ??= GetSys<SquadSystem>();
         _squad.AssignSquad(marine, (squad, squad), null);
         return marine;

--- a/Content.Server/_RMC14/Xenonids/Construction/XenoPylonSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Construction/XenoPylonSystem.cs
@@ -81,6 +81,11 @@ public sealed class XenoPylonSystem : SharedXenoPylonSystem
     private void UpdateGhostRoles(Entity<HivePylonComponent, GhostRoleMobSpawnerComponent> coreEnt)
     {
         var (uid, core, spawner) = coreEnt;
+        // Stories-HvH-Tweak-Start
+        EntityUid? hiveUid = null;
+        if (TryComp<HiveMemberComponent>(uid, out var pylonMember))
+            hiveUid = pylonMember.Hive;
+        // Stories-HvH-Tweak-End
         for (var i = core.LiveLesserDrones.Count - 1; i >= 0; i--)
         {
             var drone = core.LiveLesserDrones[i];
@@ -94,22 +99,23 @@ public sealed class XenoPylonSystem : SharedXenoPylonSystem
         }
 
         _ghostRole.SetCurrent((uid, spawner), core.LiveLesserDrones.Count);
-
-        if (!_evolution.HasLiving<XenoComponent>(1) &&
-            !_evolution.HasLiving<XenoEvolutionGranterComponent>(1))
+        // Stories-HvH-Tweak-Start
+        if (!_evolution.HasLiving<XenoComponent>(1, hiveUid) && 
+            !_evolution.HasLiving<XenoEvolutionGranterComponent>(1, hiveUid))
         {
             _ghostRole.SetAvailable((uid, spawner), 0);
             return;
         }
 
-        var living = _evolution.GetLiving<XenoComponent>(x => x.Comp.CountedInSlots);
+        var living = _evolution.GetLiving<XenoComponent>(hiveUid, x => x.Comp.CountedInSlots);
+        // Stories-HvH-Tweak-End
         var available = Math.Max(core.MinimumLesserDrones, living / core.XenosPerLesserDrone);
         core.MaxLesserDrones = available;
 
         var time = _timing.CurTime;
         if (time > core.NextLesserDroneAt)
         {
-            var hasOvipositor = _evolution.HasLiving<XenoAttachedOvipositorComponent>(1);
+            var hasOvipositor = _evolution.HasLiving<XenoAttachedOvipositorComponent>(1, hiveUid); // Stories-HvH-Tweak
             core.NextLesserDroneAt = time + (hasOvipositor ? core.NextLesserDroneOviCooldown : core.NextLesserDroneCooldown * 2);
             core.CurrentLesserDrones = Math.Min(core.MaxLesserDrones, core.CurrentLesserDrones + 1);
         }

--- a/Content.Server/_Stories/Administration/Commands/StoriesExtensions.Toolshed.cs
+++ b/Content.Server/_Stories/Administration/Commands/StoriesExtensions.Toolshed.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Robust.Shared.Console;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Player;
+using Robust.Shared.Toolshed;
+using Robust.Shared.Toolshed.Syntax;
+using Robust.Shared.Toolshed.TypeParsers;
+
+namespace Content.Server._Stories.Administration;
+
+[ToolshedCommand, AdminCommand(AdminFlags.Admin)]
+public sealed class MobStateCommand : ToolshedCommand
+{
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+
+    [CommandImplementation("is")]
+    public EntityUid? Is(
+        [CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] EntityUid ent,
+        [CommandArgument] MobState targetState)
+    {
+        if (!_entityManager.TryGetComponent<MobStateComponent>(ent, out var mobStateComponent))
+            return null;
+
+        return mobStateComponent.CurrentState == targetState ? ent : null;
+    }
+
+    [CommandImplementation("is")]
+    public IEnumerable<EntityUid> Is(
+        [CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] IEnumerable<EntityUid> ents,
+        [CommandArgument] MobState targetState)
+    {
+        return ents.Select(ent => Is(ctx, ent, targetState)).OfType<EntityUid>();
+    }
+}

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -3,6 +3,8 @@ using System.Text.RegularExpressions;
 using Content.Shared._RMC14.Chat;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Evolution;
+using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared._Stories.Xenonids;
 using Content.Shared.Popups;
 using Content.Shared.Radio;
 using Content.Shared.Speech;
@@ -144,13 +146,39 @@ public abstract class SharedChatSystem : EntitySystem
 
         if (firstChar == RadioCommonPrefix)
         {
+            // Stories-Chat-Tweak-Start
             output = SanitizeMessageCapital(message[1..].TrimStart());
-            channel = HasComp<XenoComponent>(source)
-                ? _prototypeManager.Index<RadioChannelPrototype>(HivemindChannel)
-                : _prototypeManager.Index<RadioChannelPrototype>(CommonChannel);
 
-            if (channel.ID == HivemindChannel &&
-                !_xenoEvolution.HasLiving<XenoEvolutionGranterComponent>(1))
+            string xenoHivemindChannelId = HivemindChannel;
+            if (HasComp<XenoComponent>(source) &&
+                TryComp<XenoHivemindChannelComponent>(source, out var xenoHivemindChannelComp))
+            {
+                var indexedChannel = _prototypeManager.Index<RadioChannelPrototype>(xenoHivemindChannelComp.Channel);
+
+                if (indexedChannel.IsXenoHivemind) 
+                    xenoHivemindChannelId = xenoHivemindChannelComp.Channel;
+            }
+
+            if (HasComp<XenoComponent>(source))
+                channel = _prototypeManager.Index<RadioChannelPrototype>(xenoHivemindChannelId);
+            else
+                channel = _prototypeManager.Index<RadioChannelPrototype>(CommonChannel);
+
+            Logger.Debug($"chanId: {channel.ID}");
+            Logger.Debug($"xenohvid: {xenoHivemindChannelId}");
+
+            if (!TryComp<HiveMemberComponent>(source, out var hiveMember))
+            {
+                if (!quiet)
+                    _popup.PopupEntity(Loc.GetString("rmc-no-queen-hivemind-chat"), source, source, PopupType.LargeCaution);
+
+                return false;
+            }
+
+            if (HasComp<XenoComponent>(source) &&
+                channel.ID == xenoHivemindChannelId &&
+                !_xenoEvolution.HasLiving<XenoEvolutionGranterComponent>(1, hiveMember.Hive))
+                // Stories-Chat-Tweak-End
             {
                 if (!quiet)
                     _popup.PopupEntity(Loc.GetString("rmc-no-queen-hivemind-chat"), source, source, PopupType.LargeCaution);

--- a/Content.Shared/_RMC14/Chat/SharedCMChatSystem.cs
+++ b/Content.Shared/_RMC14/Chat/SharedCMChatSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Chat;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
+using Content.Shared._Stories.Xenonids;
 
 namespace Content.Shared._RMC14.Chat;
 
@@ -16,13 +17,13 @@ public abstract class SharedCMChatSystem : EntitySystem
 
     private void OnMarineGetPrefix(Entity<MarineComponent> ent, ref ChatGetPrefixEvent args)
     {
-        if (args.Channel?.ID == SharedChatSystem.HivemindChannel.Id)
+        if (args.Channel != null && args.Channel.IsXenoHivemind) // Stories-Chat-Tweak
             args.Channel = null;
     }
 
     private void OnXenoGetPrefix(Entity<XenoComponent> ent, ref ChatGetPrefixEvent args)
     {
-        if (args.Channel?.ID != SharedChatSystem.HivemindChannel.Id)
+        if (args.Channel != null && !args.Channel.IsXenoHivemind) // Stories-Chat-Tweak
             args.Channel = null;
     }
 

--- a/Content.Shared/_RMC14/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/_RMC14/Radio/RadioChannelPrototype.cs
@@ -6,4 +6,7 @@ public sealed partial class RadioChannelPrototype
 {
     [DataField]
     public Color? ColorblindColor;
+
+    [DataField] // Stories-Chat-Tweak
+    public bool IsXenoHivemind;
 }

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -72,10 +72,12 @@ public sealed class XenoEvolutionSystem : EntitySystem
     private readonly HashSet<EntityUid> _intersecting = new();
 
     private EntityQuery<MobStateComponent> _mobStateQuery;
+    private EntityQuery<HiveMemberComponent> _memberQuery;
 
     public override void Initialize()
     {
         _mobStateQuery = GetEntityQuery<MobStateComponent>();
+        _memberQuery = GetEntityQuery<HiveMemberComponent>();
 
         SubscribeLocalEvent<XenoDevolveComponent, XenoOpenDevolveActionEvent>(OnXenoOpenDevolveAction);
 
@@ -135,7 +137,8 @@ public sealed class XenoEvolutionSystem : EntitySystem
         args.Handled = true;
         _ui.OpenUi(xeno.Owner, XenoEvolutionUIKey.Key, xeno);
 
-        var state = new XenoEvolveBuiState(LackingOvipositor());
+        var xenoHive = _xenoHive.GetHive(xeno.Owner)?.Owner;
+        var state = new XenoEvolveBuiState(LackingOvipositor(xenoHive)); // Stories-Hive-Fix
         _ui.SetUiState(xeno.Owner, XenoEvolutionUIKey.Key, state);
     }
 
@@ -300,10 +303,10 @@ public sealed class XenoEvolutionSystem : EntitySystem
         if (_net.IsClient)
             return;
 
-        var xenos = EntityQueryEnumerator<ActorComponent, XenoEvolutionComponent>();
-        var state = new XenoEvolveBuiState(LackingOvipositor());
-        while (xenos.MoveNext(out var uid, out _, out _))
+        var xenos = EntityQueryEnumerator<ActorComponent, XenoEvolutionComponent, HiveMemberComponent>();
+        while (xenos.MoveNext(out var uid, out _, out _, out var member))
         {
+            var state = new XenoEvolveBuiState(LackingOvipositor(member.Hive)); // Stories-Hive-Fix
             _ui.SetUiState(uid, XenoEvolutionUIKey.Key, state);
         }
     }
@@ -344,9 +347,9 @@ public sealed class XenoEvolutionSystem : EntitySystem
         if (!ContainedCheckPopup(xeno, doPopup))
             return false;
 
-        // TODO RMC14 revive jelly when added should not bring back dead queens
+        var xenoHive = _xenoHive.GetHive(xeno.Owner)?.Owner;
         if (prototype.TryGetComponent(out XenoEvolutionCappedComponent? capped, _compFactory) &&
-            HasLiving<XenoEvolutionCappedComponent>(capped.Max, e => e.Comp.Id == capped.Id))
+            HasLiving<XenoEvolutionCappedComponent>(capped.Max, xenoHive, e => e.Comp.Id == capped.Id)) // Stories-Hive-Fix
         {
             if (doPopup)
                 _popup.PopupEntity(Loc.GetString("cm-xeno-evolution-failed-already-have", ("prototype", prototype.Name)), xeno, xeno, PopupType.MediumCaution);
@@ -354,8 +357,8 @@ public sealed class XenoEvolutionSystem : EntitySystem
             return false;
         }
 
-        // TODO RMC14 only allow evolving towards Queen if none is alive
-        if (!xeno.Comp.CanEvolveWithoutGranter && !HasLiving<XenoEvolutionGranterComponent>(1))
+        // Stories-Hive-Fix
+        if (!xeno.Comp.CanEvolveWithoutGranter && !HasLiving<XenoEvolutionGranterComponent>(1, xenoHive))
         {
             if (doPopup)
             {
@@ -369,7 +372,6 @@ public sealed class XenoEvolutionSystem : EntitySystem
 
             return false;
         }
-
 
         if (TryComp<RestrictEvolveOffWeedsComponent>(xeno.Owner, out var comp))
         {
@@ -487,9 +489,8 @@ public sealed class XenoEvolutionSystem : EntitySystem
         return false;
     }
 
-    // TODO RMC14 make this a property of the hive component
-    // TODO RMC14 per-hive
-    public int GetLiving<T>(Predicate<Entity<T>>? predicate = null) where T : IComponent
+    // Stories-Hive-Fix-Start
+    public int GetLiving<T>(EntityUid? hive = null, Predicate<Entity<T>>? predicate = null) where T : IComponent
     {
         var total = 0;
         var query = EntityQueryEnumerator<T>();
@@ -501,6 +502,12 @@ public sealed class XenoEvolutionSystem : EntitySystem
                 continue;
             }
 
+            if (hive != null)
+            {
+                if (!_memberQuery.TryComp(uid, out var member) || member.Hive != hive)
+                    continue;
+            }
+
             if (predicate != null && !predicate((uid, comp)))
                 continue;
 
@@ -510,9 +517,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
         return total;
     }
 
-    // TODO RMC14 make this a property of the hive component
-    // TODO RMC14 per-hive
-    public bool HasLiving<T>(int count, Predicate<Entity<T>>? predicate = null) where T : IComponent
+    public bool HasLiving<T>(int count, EntityUid? hive = null, Predicate<Entity<T>>? predicate = null) where T : IComponent
     {
         if (count <= 0)
             return true;
@@ -527,6 +532,12 @@ public sealed class XenoEvolutionSystem : EntitySystem
                 continue;
             }
 
+            if (hive != null)
+            {
+                if (!_memberQuery.TryComp(uid, out var member) || member.Hive != hive)
+                    continue;
+            }
+
             if (predicate != null && !predicate((uid, comp)))
                 continue;
 
@@ -538,6 +549,7 @@ public sealed class XenoEvolutionSystem : EntitySystem
 
         return false;
     }
+    // Stories-Hive-Fix-End
 
     public void SetPoints(Entity<XenoEvolutionComponent> evolution, FixedPoint2 points)
     {
@@ -550,14 +562,16 @@ public sealed class XenoEvolutionSystem : EntitySystem
         return _gameTicker.RoundDuration() > _evolutionPointsRequireOvipositorAfter;
     }
 
-    public bool HasOvipositor()
+    // Stories-Hive-Fix
+    public bool HasOvipositor(EntityUid? hive = null)
     {
-        return HasLiving<XenoEvolutionGranterComponent>(1, e => HasComp<XenoAttachedOvipositorComponent>(e));
+        return HasLiving<XenoEvolutionGranterComponent>(1, hive, e => HasComp<XenoAttachedOvipositorComponent>(e));
     }
 
-    public bool LackingOvipositor()
+    // Stories-Hive-Fix
+    public bool LackingOvipositor(EntityUid? hive = null)
     {
-        return NeedsOvipositor() && !HasOvipositor();
+        return NeedsOvipositor() && !HasOvipositor(hive);
     }
 
     private EntityUid TransferXeno(EntityUid xeno, EntProtoId proto)
@@ -680,9 +694,8 @@ public sealed class XenoEvolutionSystem : EntitySystem
         var time = _timing.CurTime;
         var roundDuration = _gameTicker.RoundDuration();
         var needsOvipositor = NeedsOvipositor();
-        var hasGranter = needsOvipositor
-            ? HasOvipositor()
-            : HasLiving<XenoEvolutionGranterComponent>(1);
+
+        // Stories-Hive-Fix
         if (needsOvipositor)
         {
             var granters = EntityQueryEnumerator<XenoEvolutionGranterComponent>();
@@ -739,12 +752,21 @@ public sealed class XenoEvolutionSystem : EntitySystem
                 _audio.PlayEntity(comp.EvolutionReadySound, uid, uid);
                 continue;
             }
+
             var points = (_earlyEvoBoostBefore > _gameTicker.RoundDuration()) ? comp.EarlyPointsPerSecond : comp.PointsPerSecond;
             var gain = evoOverride ?? points + evoBonus;
+            
             if (comp.Points < comp.Max || roundDuration < _evolutionAccumulatePointsBefore)
             {
-                if (needsOvipositor && comp.RequiresGranter && !hasGranter)
-                    continue;
+                // Stories-Hive-Fix
+                if (needsOvipositor && comp.RequiresGranter)
+                {
+                    var xenoHive = _xenoHive.GetHive(uid)?.Owner;
+                    var hasHiveGranter = HasLiving<XenoEvolutionGranterComponent>(1, xenoHive, e => HasComp<XenoAttachedOvipositorComponent>(e));
+                    
+                    if (!hasHiveGranter)
+                        continue;
+                }
 
                 SetPoints((uid, comp), comp.Points + gain);
             }

--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -624,6 +624,8 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
                 EnsureComp<ParasiteSpentComponent>(uid);
 
                 infectable.BeingInfected = false;
+
+                SetBurstSpawn((infectedVictim, victimComp), para.BurstProto);  // Stories-Infected-Proto-Tweak
                 Dirty(infectedVictim, infectable);
             }
         }

--- a/Content.Shared/_RMC14/Xenonids/Parasite/XenoParasiteComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/XenoParasiteComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Robust.Shared.GameStates;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._RMC14.Xenonids.Parasite;
 
@@ -33,4 +34,8 @@ public sealed partial class XenoParasiteComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool FellOff;
+
+    // Stories-Infected-Proto-Tweak
+    [DataField, AutoNetworkedField]
+    public EntProtoId BurstProto = "CMXenoLarva";
 }

--- a/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
@@ -61,6 +61,8 @@ public sealed class XenoScreechSystem : EntitySystem
         _closeMobs.Clear();
         _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.ParalyzeRange, _closeMobs);
 
+        _closeMobs.RemoveWhere(uid => HasComp<XenoScreechComponent>(uid)); // Stories-HiveVsHive-Screech-Fix
+
         foreach (var receiver in _closeMobs)
         {
             if (!_xeno.CanAbilityAttackTarget(xeno, receiver))
@@ -72,6 +74,7 @@ public sealed class XenoScreechSystem : EntitySystem
 
         _mobs.Clear();
         _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.StunRange, _mobs);
+        _mobs.RemoveWhere(uid => HasComp<XenoScreechComponent>(uid)); // Stories-HiveVsHive-Screech-Fix
 
         foreach (var receiver in _mobs)
         {

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -23,6 +23,7 @@ using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared._RMC14.Xenonids.ScissorCut;
 using Content.Shared._RMC14.Xenonids.Weeds;
+using Content.Shared._Stories.Xenonids;
 using Content.Shared.Access.Components;
 using Content.Shared.Actions;
 using Content.Shared.Atmos;
@@ -82,6 +83,7 @@ public sealed partial class XenoSystem : EntitySystem
     [Dependency] private readonly WeldableSystem _weldable = default!;
     [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
     [Dependency] private readonly SharedXenoWeedsSystem _weeds = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
     private static readonly ProtoId<DamageTypePrototype> HeatDamage = "Heat";
 
@@ -201,7 +203,15 @@ public sealed partial class XenoSystem : EntitySystem
 
     private void OnXenoGetDefaultRadioChannel(Entity<XenoComponent> ent, ref GetDefaultRadioChannelEvent args)
     {
-        args.Channel = SharedChatSystem.HivemindChannel;
+        if (!TryComp<XenoHivemindChannelComponent>(ent, out var xenoHivemindChannelComp))
+        {
+            args.Channel = SharedChatSystem.HivemindChannel;
+            return;
+        }
+
+        var indexedChannel = _prototypeManager.Index<RadioChannelPrototype>(xenoHivemindChannelComp.Channel);
+
+        args.Channel = indexedChannel.IsXenoHivemind ? indexedChannel : SharedChatSystem.HivemindChannel;
     }
 
     private void OnXenoAttackAttempt(Entity<XenoComponent> xeno, ref AttackAttemptEvent args)

--- a/Content.Shared/_Stories/Administation/Components/AssignHiveOnSpawnComponent.cs
+++ b/Content.Shared/_Stories/Administation/Components/AssignHiveOnSpawnComponent.cs
@@ -1,0 +1,12 @@
+using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Stories.Extensions;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(StoriesExtensions))]
+public sealed partial class AssignHiveOnSpawnComponent : Component
+{
+    [DataField(required: true), AutoNetworkedField]
+    public EntityWhitelist? Whitelist;
+}

--- a/Content.Shared/_Stories/Administation/Components/AssignSquadOnSpawnComponent.cs
+++ b/Content.Shared/_Stories/Administation/Components/AssignSquadOnSpawnComponent.cs
@@ -1,0 +1,12 @@
+using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Stories.Extensions;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(StoriesExtensions))]
+public sealed partial class AssignSquadOnSpawnComponent : Component
+{
+    [DataField(required: true), AutoNetworkedField]
+    public EntityWhitelist? Whitelist;
+}

--- a/Content.Shared/_Stories/Administation/StoriesExtensions.cs
+++ b/Content.Shared/_Stories/Administation/StoriesExtensions.cs
@@ -1,0 +1,42 @@
+using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared._RMC14.Marines.Squads;
+using Content.Shared.Whitelist;
+
+namespace Content.Shared._Stories.Extensions;
+
+public sealed partial class StoriesExtensions : EntitySystem
+{
+    [Dependency] private readonly SquadSystem _squad = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _hive = default!;
+    [Dependency] private readonly EntityWhitelistSystem _entityWhitelist = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<AssignSquadOnSpawnComponent, MapInitEvent>(AssignSquadOnInit);
+        SubscribeLocalEvent<AssignHiveOnSpawnComponent, MapInitEvent>(AssignHiveOnInit);
+    }
+
+    private void AssignSquadOnInit(Entity<AssignSquadOnSpawnComponent> ent, ref MapInitEvent args)
+    {
+        var query = EntityQueryEnumerator<SquadTeamComponent>();
+        while (query.MoveNext(out var squad, out var comp))
+        {
+            if (!_entityWhitelist.IsWhitelistPass(ent.Comp.Whitelist, squad))
+                continue;
+
+            _squad.AssignSquad(ent, (squad, comp), null);
+        }
+    }
+
+    private void AssignHiveOnInit(Entity<AssignHiveOnSpawnComponent> ent, ref MapInitEvent args)
+    {
+        var query = EntityQueryEnumerator<HiveComponent>();
+        while (query.MoveNext(out var hive, out var comp))
+        {
+            if (!_entityWhitelist.IsWhitelistPass(ent.Comp.Whitelist, hive))
+                continue;
+
+            _hive.SetHive(ent.Owner, hive);
+        }
+    }
+}

--- a/Content.Shared/_Stories/Xenonids/XenoBoxer/BoxerJab/BoxerJabSystem.cs
+++ b/Content.Shared/_Stories/Xenonids/XenoBoxer/BoxerJab/BoxerJabSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._RMC14.Slow;
+using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Weapons.Melee;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._Stories.Xenonids.XenoBoxer.BoxerPunch;
@@ -35,6 +36,9 @@ public sealed class BoxerJabSystem : EntitySystem
             return;
 
         if (!_xeno.CanAbilityAttackTarget(xeno, args.Target))
+            return;
+
+        if (TryComp<RMCSizeComponent>(args.Target, out var targetSize) && targetSize.Size == RMCSizes.Immobile)
             return;
 
         args.Handled = true;

--- a/Content.Shared/_Stories/Xenonids/XenoBoxer/BoxerPunch/BoxerPunchSystem.cs
+++ b/Content.Shared/_Stories/Xenonids/XenoBoxer/BoxerPunch/BoxerPunchSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._RMC14.Pulling;
 using Content.Shared._RMC14.Slow;
+using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Weapons.Melee;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._Stories.Xenonids.XenoBoxer.BoxerJab;
@@ -41,6 +42,9 @@ public sealed class BoxerPunchSystem : EntitySystem
         var targetUid = args.Target;
 
         if (!_xeno.CanAbilityAttackTarget(xeno, targetUid))
+            return;
+
+        if (TryComp<RMCSizeComponent>(targetUid, out var targetSize) && targetSize.Size == RMCSizes.Immobile)
             return;
 
         args.Handled = true;

--- a/Content.Shared/_Stories/Xenonids/XenoBoxer/BoxerUppercut/BoxerUppercutSystem.cs
+++ b/Content.Shared/_Stories/Xenonids/XenoBoxer/BoxerUppercut/BoxerUppercutSystem.cs
@@ -62,6 +62,9 @@ public sealed class BoxerUppercutSystem : EntitySystem
         if (!_xeno.CanAbilityAttackTarget(xeno, targetUid))
             return;
 
+        if (TryComp<RMCSizeComponent>(targetUid, out var targetSize) && targetSize.Size == RMCSizes.Immobile)
+            return;
+            
         args.Handled = true;
 
         if (!TryComp(xeno, out XenoBoxerKnockoutComponent? knockoutComp) ||

--- a/Content.Shared/_Stories/Xenonids/XenoHivemindChannelComponent.cs
+++ b/Content.Shared/_Stories/Xenonids/XenoHivemindChannelComponent.cs
@@ -1,0 +1,13 @@
+using Content.Shared.Chat;
+using Content.Shared.Radio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Stories.Xenonids;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class XenoHivemindChannelComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public ProtoId<RadioChannelPrototype> Channel = SharedChatSystem.HivemindChannel;
+}

--- a/Resources/Prototypes/_RMC14/radio_channels.yml
+++ b/Resources/Prototypes/_RMC14/radio_channels.yml
@@ -208,3 +208,4 @@
   frequency: 426
   color: "#8b36a6"
   longRange: true
+  isXenoHivemind: true


### PR DESCRIPTION
## Описание PR
Добавлены несколько полезных компонентов: 

`AssignHiveOnSpawnComponent` выдает ксеноморфу указанный через вайтлист улей при спавне

`AssignSquadOnSpawnComponent` выдает игроку указанный через вайтлист отряд при инициализации сущности(не путать с `AssignSquadComponent` они разные)

`XenoHivemindChannelComponent` позволяет установить ксеноморфу другой хайвмайнд, также вместе с этим компонентом изменены три системы `XenoSystem`, `SharedChatSystem`, `SharedCMChatSystem`. Оттуда вырезан хардкод для того, чтобы ксеноморфу можно было указать другой хайвмайнд

Также изменения затрагивают крик королевы, эволюцию ксено, боксера. Теперь крик не станит Королев вообще, боксер не может отпинать квину, а эволюции теперь корректно работают между разными ульями

Из мелких изменений - лицехвату можно указать в прототипе какая личинка вылезет из зараженного, а также добавлена новая тулшед команда позволяющая фильтровать сущности по их MobState
**Медиа**
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт. -->

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
