### PR TITLE
Золотая Матеба и Peregrine  250 часов

### DIFF
--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/RoleSpecific/commanding_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/RoleSpecific/commanding_officer.yml
@@ -55,7 +55,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: CMJobCommandingOfficer
-      time: 900000 # 250 hrs # Stories
+      time: 900000 # 250 hrs
   storage:
     back:
     - RMCMatebaCustomizationCaseLuxuryWeapon
@@ -67,7 +67,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: CMJobCommandingOfficer
-      time: 1800000 # 500 hrs # Stories
+      time: 900000 #250 hrs
   storage:
     back:
     - RMCWeaponPistolHandcannonGold

--- a/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/RoleSpecific/commanding_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Loadouts/Items/RoleSpecific/commanding_officer.yml
@@ -55,7 +55,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: CMJobCommandingOfficer
-      time: 1800000 # 500 hrs # Stories
+      time: 900000 # 250 hrs # Stories
   storage:
     back:
     - RMCMatebaCustomizationCaseLuxuryWeapon


### PR DESCRIPTION
## Описание PR
Снижено требование для золотой Матебы и Peregrine  командующего офицера с 500 до 250 часов.

## Причина / Баланс
Текущее требование в 500 часов фактически недостижимо: самое большое известное время у одного игрока на командующем офицере составляет 343 часа. Значение в 250 часов оставляет предмет редкой косметической наградой, но делает его достижимой целью после получения звания и долгой игры на роли.

## Технические детали
Изменены значения `RoleTimeRequirement` для `GoldMatebaRMC`: `1800000` -> `900000`   `GoldHandcannonRMC`-> `900000`.

## Медиа
Не требуется, изменение касается только требования по времени.

**Changelog (Список изменений)**
- tweak: Требование для открытия золотой Матебы и  Peregrine  командующего офицера снижено до 250 часов.
