### PR TITLE
Исправлены теги hunter-предметов и debug-сетевые сообщения

### DIFF
--- a/Content.Shared/Players/MsgRoleBans.cs
+++ b/Content.Shared/Players/MsgRoleBans.cs
@@ -8,7 +8,6 @@ namespace Content.Shared.Players;
 /// <summary>
 /// Sent server -> client to inform the client of their role bans.
 /// </summary>
-[Serializable, NetSerializable]
 public sealed class MsgRoleBans : NetMessage
 {
     public override MsgGroups MsgGroup => MsgGroups.EntityEvent;

--- a/Content.Shared/Players/PlayTimeTracking/MsgPlayTime.cs
+++ b/Content.Shared/Players/PlayTimeTracking/MsgPlayTime.cs
@@ -8,7 +8,6 @@ namespace Content.Shared.Players.PlayTimeTracking;
 /// <summary>
 /// Sent server -> client to inform the client of their play times.
 /// </summary>
-[Serializable, NetSerializable]
 public sealed class MsgPlayTime : NetMessage
 {
     public override MsgGroups MsgGroup => MsgGroups.EntityEvent;

--- a/Content.Shared/Preferences/MsgDeleteCharacter.cs
+++ b/Content.Shared/Preferences/MsgDeleteCharacter.cs
@@ -8,7 +8,6 @@ namespace Content.Shared.Preferences
     /// <summary>
     /// The client sends this to delete a character profile.
     /// </summary>
-    [Serializable, NetSerializable] // Stories-Hunter
     public sealed class MsgDeleteCharacter : NetMessage
     {
         public override MsgGroups MsgGroup => MsgGroups.Command;

--- a/Content.Shared/Preferences/MsgPreferencesAndSettings.cs
+++ b/Content.Shared/Preferences/MsgPreferencesAndSettings.cs
@@ -9,7 +9,6 @@ namespace Content.Shared.Preferences
     /// <summary>
     /// The server sends this before the client joins the lobby.
     /// </summary>
-    [Serializable, NetSerializable] // Stories-Hunter
     public sealed class MsgPreferencesAndSettings : NetMessage
     {
         public override MsgGroups MsgGroup => MsgGroups.Command;

--- a/Content.Shared/Preferences/MsgSelectCharacter.cs
+++ b/Content.Shared/Preferences/MsgSelectCharacter.cs
@@ -8,7 +8,6 @@ namespace Content.Shared.Preferences
     /// <summary>
     /// The client sends this to select a character slot.
     /// </summary>
-    [Serializable, NetSerializable] // Stories-Hunter
     public sealed class MsgSelectCharacter : NetMessage
     {
         public override MsgGroups MsgGroup => MsgGroups.Command;

--- a/Content.Shared/Preferences/MsgUpdateCharacter.cs
+++ b/Content.Shared/Preferences/MsgUpdateCharacter.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using Lidgren.Network;
 using Robust.Shared.Network;
@@ -9,7 +8,6 @@ namespace Content.Shared.Preferences
     /// <summary>
     /// The client sends this to update a character profile.
     /// </summary>
-    [Serializable, NetSerializable] // Stories-Hunter
     public sealed class MsgUpdateCharacter : NetMessage
     {
         public override MsgGroups MsgGroup => MsgGroups.Command;

--- a/Content.Shared/Preferences/MsgUpdateConstructionFavorites.cs
+++ b/Content.Shared/Preferences/MsgUpdateConstructionFavorites.cs
@@ -1,4 +1,3 @@
-using System;
 using Content.Shared.Construction.Prototypes;
 using Lidgren.Network;
 using Robust.Shared.Network;
@@ -10,7 +9,6 @@ namespace Content.Shared.Preferences;
 /// <summary>
 /// The client sends this to update their construction favorites.
 /// </summary>
-[Serializable, NetSerializable] // Stories-Hunter
 public sealed class MsgUpdateConstructionFavorites : NetMessage
 {
     public override MsgGroups MsgGroup => MsgGroups.Command;

--- a/Resources/Prototypes/_Stories/tags.yml
+++ b/Resources/Prototypes/_Stories/tags.yml
@@ -23,10 +23,19 @@
   id: STPlasmaCaster
 
 - type: Tag
+  id: STPlasmaCasterHolder
+
+- type: Tag
   id: STBracerAttachment
 
 - type: Tag
   id: STHunterMaskAccessory
+
+- type: Tag
+  id: STHunterMelee
+
+- type: Tag
+  id: STPredatorBow
 
 - type: Tag
   id: STHunterArrow

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1461,6 +1461,9 @@
   id: WeldingMask
 
 - type: Tag
+  id: Welder
+
+- type: Tag
   id: WetFloorSign
 
 - type: Tag


### PR DESCRIPTION
## Описание PR

Исправляет проблемы debug-сборки и YAML-прототипов, связанные с hunter-предметами.

- Убраны лишние атрибуты сетевой сериализации с `NetMessage`, которые ломали debug-сборку.
- Добавлены недостающие `TagPrototype` для hunter-экипировки.
- Добавлен общий тег `Welder`, который используется в прототипах.

## Причина / Баланс

Изменения не должны влиять на баланс. PR чинит технические ошибки: сборку в Debug и отсутствующие теги у предметов/экипировки.

## Технические детали

- С `NetMessage`-классов убраны некорректные `[Serializable, NetSerializable]`.
- В прототипы тегов добавлены:
  - `STPlasmaCasterHolder`
  - `STHunterMelee`
  - `STPredatorBow`
  - `Welder`
- Локально проверено, что ST-теги hunter-предметов соответствуют объявленным `TagPrototype`.

## Медиа

Не требуется: PR не добавляет визуальные изменения и не меняет игровой контент напрямую.

## Требования

- [x] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [x] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение.
- [x] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями.

**Changelog (Список изменений)**

- fix: Исправлены ошибки debug-сборки сетевых сообщений. Добавлены недостающие теги для hunter-предметов.
