### PR TITLE
XM51 to admin spawn only

### DIFF
--- a/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Cargo/requisitions_catalog.yml
@@ -61,8 +61,6 @@
       - cost: 4000
         crate: RMCCrateBoxMagazineSmartPistol
       - cost: 2000
-        crate: RMCCrateBoxMagazineBreaching
-      - cost: 2000
         crate: RMCCrateBoxMagazineM54CE2
       - cost: 2000
         crate: RMCCrateBoxMagazineM44Revolver
@@ -363,8 +361,6 @@
         crate: RMCCrateM34
       - cost: 3000
         crate: RMCCrateMOU53
-      - cost: 3000
-        crate: RMCCrateXM51
       - cost: 4000
         crate: RMCCrateM85A1
       - cost: 6000

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Crew/requisitions.yml
@@ -78,8 +78,6 @@
         amount: 3
       - id: RMCGunCasePistolM13
         amount: 3
-      - id: RMCXM51Case
-        amount: 3
     - name: Explosives
       entries:
       - id: CMGrenadeFragOld
@@ -379,8 +377,6 @@
         amount: 56
       - id: RMCBoxShotgunSlugs
         amount: 56
-      - id: RMCBoxShotgunBreaching
-        amount: 4
       - id: CMMagazineRifleM4SPR
         amount: 60
       - id: CMMagazineRifleM54C
@@ -453,8 +449,6 @@
         amount: 2
       - id: RMCMagazineM2C
         amount: 2
-      - id: RMCMagazineShotgunXM51
-        amount: 3
     - name: Magazine Boxes
       hasBoxes: true
       entries:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/requisitions.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/requisitions.yml
@@ -22,8 +22,6 @@
       - RMCCrateBoxShellsShotgunSlugs
       - RMCCrateBoxShellsShotgunBuckshot
       - RMCCrateBoxShellsShotgunFlechette
-      - RMCCrateBoxShellsShotgunBreaching
-      - RMCCrateBoxMagazineBreaching
       - RMCCrateMagazineSmartGun
       - RMCCrateMagazineNapthalUT
       - RMCCrateMagazineBGel


### PR DESCRIPTION
## Описание PR
Перенос XM51 в админ спавн

## Причина / Баланс
Хоть оффы отказались удалять XM51, но они хотят забалансить BRUTE. Так что, пока не будет баланса между ними, лучше будет удалить XM51, до лучших времен, чтобы морпехи не могли сносить целые здания, не тратя свое драгоценное время

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [X] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
- [X] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.

**Changelog (Список изменений)**
:cl:
- remove: Удаление XM51 из общего доступа (только админ спавн)

