### PR TITLE
Задержка для остановки перегрузки реактора ксено

### DIFF
--- a/Content.Shared/_RMC14/Power/RMCFusionReactorComponent.cs
+++ b/Content.Shared/_RMC14/Power/RMCFusionReactorComponent.cs
@@ -42,6 +42,9 @@ public sealed partial class RMCFusionReactorComponent : Component
     public TimeSpan OverloadDelay = TimeSpan.FromSeconds(2);
 
     [DataField, AutoNetworkedField]
+    public TimeSpan XenoOverloadStopDelay = TimeSpan.FromSeconds(2);
+
+    [DataField, AutoNetworkedField]
     public EntProtoId<SkillDefinitionComponent> OverloadSkill = "RMCSkillEngineer";
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Power/RMCFusionReactorStopOverloadDoAfterEvent.cs
+++ b/Content.Shared/_RMC14/Power/RMCFusionReactorStopOverloadDoAfterEvent.cs
@@ -1,0 +1,7 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Power;
+
+[Serializable, NetSerializable]
+public sealed partial class RMCFusionReactorStopOverloadDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/_RMC14/Power/SharedRMCPowerSystem.cs
+++ b/Content.Shared/_RMC14/Power/SharedRMCPowerSystem.cs
@@ -94,6 +94,7 @@ public abstract class SharedRMCPowerSystem : EntitySystem
         SubscribeLocalEvent<RMCFusionReactorComponent, RMCFusionReactorRepairDoAfterEvent>(OnFusionReactorRepairWeldingDoAfter);
         SubscribeLocalEvent<RMCFusionReactorComponent, RMCFusionReactorOverloadDoAfterEvent>(OnFusionReactorOverloadDoAfter);
         SubscribeLocalEvent<RMCFusionReactorComponent, InteractHandEvent>(OnFusionReactorInteractHand);
+        SubscribeLocalEvent<RMCFusionReactorComponent, RMCFusionReactorStopOverloadDoAfterEvent>(OnFusionReactorStopOverloadDoAfter);
         SubscribeLocalEvent<RMCFusionReactorComponent, RMCFusionReactorDestroyDoAfterEvent>(OnFusionReactorDestroyDoAfter);
         SubscribeLocalEvent<RMCFusionReactorComponent, ExaminedEvent>(OnFusionReactorExamined);
 
@@ -361,6 +362,9 @@ public abstract class SharedRMCPowerSystem : EntitySystem
         var used = args.Used;
 
         args.Handled = true;
+        if (HasActiveFusionReactorDoAfter(user))
+            return;
+
         var container = _container.EnsureContainer<ContainerSlot>(ent, ent.Comp.CellContainerSlot);
         if (HasComp<RMCFusionCellComponent>(used))
         {
@@ -524,17 +528,20 @@ public abstract class SharedRMCPowerSystem : EntitySystem
         if (!HasComp<XenoComponent>(user) || !HasComp<MeleeWeaponComponent>(user))
             return;
 
+        if (HasActiveFusionReactorDoAfter(user))
+            return;
+
         if (ent.Comp.Overloaded)
         {
             args.Handled = true;
-            SetFusionReactorOverloaded(ent, false, user);
-            _popup.PopupPredicted(
-                Loc.GetString("rmc-fusion-reactor-overload-stop-xeno", ("reactor", ent)),
-                Loc.GetString("rmc-fusion-reactor-overload-stop-xeno-others", ("xeno", user), ("reactor", ent)),
-                ent,
-                user,
-                MediumCaution);
-            _audio.PlayPredicted(ent.Comp.OverloadStopSound, ent, user);
+            var stopOverloadEv = new RMCFusionReactorStopOverloadDoAfterEvent();
+            var stopOverloadDoAfter = new DoAfterArgs(EntityManager, user, ent.Comp.XenoOverloadStopDelay, stopOverloadEv, ent, ent)
+            {
+                BreakOnMove = true,
+                DuplicateCondition = DuplicateConditions.SameEvent,
+            };
+
+            _doAfter.TryStartDoAfter(stopOverloadDoAfter);
             return;
         }
 
@@ -552,6 +559,26 @@ public abstract class SharedRMCPowerSystem : EntitySystem
         };
 
         _doAfter.TryStartDoAfter(doAfter);
+    }
+
+    private void OnFusionReactorStopOverloadDoAfter(Entity<RMCFusionReactorComponent> ent, ref RMCFusionReactorStopOverloadDoAfterEvent args)
+    {
+        var user = args.User;
+        if (args.Cancelled || args.Handled)
+            return;
+
+        if (!ent.Comp.Overloaded || !HasComp<XenoComponent>(user) || !HasComp<MeleeWeaponComponent>(user))
+            return;
+
+        args.Handled = true;
+        SetFusionReactorOverloaded(ent, false, user);
+        _popup.PopupPredicted(
+            Loc.GetString("rmc-fusion-reactor-overload-stop-xeno", ("reactor", ent)),
+            Loc.GetString("rmc-fusion-reactor-overload-stop-xeno-others", ("xeno", user), ("reactor", ent)),
+            ent,
+            user,
+            MediumCaution);
+        _audio.PlayPredicted(ent.Comp.OverloadStopSound, ent, user);
     }
 
     private void OnFusionReactorDestroyDoAfter(Entity<RMCFusionReactorComponent> ent, ref RMCFusionReactorDestroyDoAfterEvent args)
@@ -706,6 +733,9 @@ public abstract class SharedRMCPowerSystem : EntitySystem
         if (_net.IsClient)
             return;
 
+        if (HasActiveFusionReactorDoAfter(user))
+            return;
+
         if (!CanToggleFusionReactorOverload(ent, user, used))
             return;
 
@@ -774,6 +804,32 @@ public abstract class SharedRMCPowerSystem : EntitySystem
     {
         return _container.TryGetContainer(ent, ent.Comp.CellContainerSlot, out var container) &&
                container.ContainedEntities.Count > 0;
+    }
+
+    private bool HasActiveFusionReactorDoAfter(EntityUid user)
+    {
+        if (!TryComp<DoAfterComponent>(user, out var doAfter))
+            return false;
+
+        foreach (var active in doAfter.DoAfters.Values)
+        {
+            if (active.Cancelled || active.Completed)
+                continue;
+
+            if (active.Args.Target is { } target &&
+                HasComp<RMCFusionReactorComponent>(target))
+            {
+                return true;
+            }
+
+            if (active.Args.EventTarget is { } eventTarget &&
+                HasComp<RMCFusionReactorComponent>(eventTarget))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public void SetFusionReactorOverloaded(Entity<RMCFusionReactorComponent> ent, bool overloaded, EntityUid? user = null)


### PR DESCRIPTION
## Описание PR

Добавляет doafter для ксено при остановке перегрузки реактора. Теперь ксено не снимает перегрузку мгновенно при клике по реактору, а начинает короткое действие, которое может быть прервано движением.

## Причина / Баланс

Изменение убирает мгновенную отмену перегрузки реактора со стороны ксено и делает взаимодействие более честным: остановка требует времени и может быть сорвана. Это снижает резкость контригры и лучше соответствует другим действиям с реактором.

## Технические детали

- Добавлено сетевое doafter-событие `RMCFusionReactorStopOverloadDoAfterEvent`.
- В `RMCFusionReactorComponent` добавлено поле `XenoOverloadStopDelay`.
- Логика остановки перегрузки ксено перенесена из мгновенного действия в обработчик doafter.
- Добавлена проверка активных doafter на реакторе, чтобы не запускать дублирующие действия.

## Медиа

Не требуется: изменение не добавляет новых визуальных ассетов.

## Требования

- [X] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [X] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
- [X] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.

**Changelog (Список изменений)**

- fix: Ксено теперь останавливают перегрузку реактора через 2  секунды, а не мгновенно.