### PR TITLE
Исправление отображения связей складных пласталевых баррикад при повороте камеры

### DIFF
--- a/Content.Client/_RMC14/Entrenching/RMCFoldingBarricadeLinkingVisualizerSystem.cs
+++ b/Content.Client/_RMC14/Entrenching/RMCFoldingBarricadeLinkingVisualizerSystem.cs
@@ -1,0 +1,107 @@
+using Content.Shared._RMC14.Entrenching;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
+using static Robust.Client.Graphics.RSI;
+
+namespace Content.Client._RMC14.Entrenching;
+
+public sealed class RMCFoldingBarricadeLinkingVisualizerSystem : EntitySystem
+{
+    [Dependency] private readonly AppearanceSystem _appearance = default!;
+    [Dependency] private readonly IEyeManager _eye = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
+    private static readonly (RMCFoldingBarricadeLinkingVisuals Visual,
+        RMCFoldingBarricadeLinkingVisualLayers Layer,
+        Direction Direction)[] ConnectionLayers =
+    [
+        (RMCFoldingBarricadeLinkingVisuals.North, RMCFoldingBarricadeLinkingVisualLayers.North, Direction.North),
+        (RMCFoldingBarricadeLinkingVisuals.South, RMCFoldingBarricadeLinkingVisualLayers.South, Direction.South),
+        (RMCFoldingBarricadeLinkingVisuals.East, RMCFoldingBarricadeLinkingVisualLayers.East, Direction.East),
+        (RMCFoldingBarricadeLinkingVisuals.West, RMCFoldingBarricadeLinkingVisualLayers.West, Direction.West),
+    ];
+
+    private Direction _lastEyeDirection = Direction.Invalid;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<RMCFoldingBarricadeLinkingComponent, AppearanceChangeEvent>(
+            OnAppearanceChange,
+            after: [typeof(GenericVisualizerSystem)]);
+    }
+
+    public override void FrameUpdate(float frameTime)
+    {
+        var eyeDirection = GetEyeDirection();
+        if (eyeDirection == _lastEyeDirection)
+            return;
+
+        _lastEyeDirection = eyeDirection;
+
+        var query = EntityQueryEnumerator<RMCFoldingBarricadeLinkingComponent, AppearanceComponent, SpriteComponent>();
+        while (query.MoveNext(out var uid, out _, out var appearance, out var sprite))
+        {
+            UpdateVisuals((uid, sprite), appearance);
+        }
+    }
+
+    private void OnAppearanceChange(Entity<RMCFoldingBarricadeLinkingComponent> ent, ref AppearanceChangeEvent args)
+    {
+        if (args.Sprite == null)
+            return;
+
+        UpdateVisuals((ent.Owner, args.Sprite), args.Component);
+    }
+
+    private void UpdateVisuals(Entity<SpriteComponent> ent, AppearanceComponent? appearance)
+    {
+        var eyeRotation = _eye.CurrentEye.Rotation;
+        var sprite = ent.AsNullable();
+
+        foreach (var (visual, layer, direction) in ConnectionLayers)
+        {
+            if (!_sprite.LayerMapTryGet(sprite, layer, out var layerIndex, false))
+                continue;
+
+            if (!_appearance.TryGetData<RMCFoldingBarricadeLinkingVisualState>(
+                    ent.Owner,
+                    visual,
+                    out var state,
+                    appearance) ||
+                state == RMCFoldingBarricadeLinkingVisualState.None)
+            {
+                _sprite.LayerSetVisible(sprite, layerIndex, false);
+                continue;
+            }
+
+            // Connection states are keyed by screen-facing side, while linking data is stored in world directions.
+            var screenDirection = (direction.ToAngle() + eyeRotation).GetCardinalDir();
+            var connection = GetConnectionSuffix(screenDirection);
+            var statePrefix = state == RMCFoldingBarricadeLinkingVisualState.Open
+                ? "folding_plasteel_closed_connection"
+                : "folding_plasteel_connection";
+
+            _sprite.LayerSetRsiState(sprite, layerIndex, new StateId($"{statePrefix}_{connection}"));
+            _sprite.LayerSetVisible(sprite, layerIndex, true);
+        }
+    }
+
+    private Direction GetEyeDirection()
+    {
+        return _eye.CurrentEye.Rotation.GetCardinalDir();
+    }
+
+    private static int GetConnectionSuffix(Direction direction)
+    {
+        return direction switch
+        {
+            Direction.North => 1,
+            Direction.South => 2,
+            Direction.East => 4,
+            Direction.West => 8,
+            _ => 1,
+        };
+    }
+}

--- a/Content.Client/_RMC14/Entrenching/RMCFoldingBarricadeLinkingVisualizerSystem.cs
+++ b/Content.Client/_RMC14/Entrenching/RMCFoldingBarricadeLinkingVisualizerSystem.cs
@@ -41,9 +41,9 @@ public sealed class RMCFoldingBarricadeLinkingVisualizerSystem : EntitySystem
         _lastEyeDirection = eyeDirection;
 
         var query = EntityQueryEnumerator<RMCFoldingBarricadeLinkingComponent, AppearanceComponent, SpriteComponent>();
-        while (query.MoveNext(out var uid, out _, out var appearance, out var sprite))
+        while (query.MoveNext(out var uid, out var linking, out var appearance, out var sprite))
         {
-            UpdateVisuals((uid, sprite), appearance);
+            UpdateVisuals((uid, sprite), linking, appearance);
         }
     }
 
@@ -52,10 +52,13 @@ public sealed class RMCFoldingBarricadeLinkingVisualizerSystem : EntitySystem
         if (args.Sprite == null)
             return;
 
-        UpdateVisuals((ent.Owner, args.Sprite), args.Component);
+        UpdateVisuals((ent.Owner, args.Sprite), ent.Comp, args.Component);
     }
 
-    private void UpdateVisuals(Entity<SpriteComponent> ent, AppearanceComponent? appearance)
+    private void UpdateVisuals(
+        Entity<SpriteComponent> ent,
+        RMCFoldingBarricadeLinkingComponent linking,
+        AppearanceComponent? appearance)
     {
         var eyeRotation = _eye.CurrentEye.Rotation;
         var sprite = ent.AsNullable();
@@ -78,12 +81,13 @@ public sealed class RMCFoldingBarricadeLinkingVisualizerSystem : EntitySystem
 
             // Connection states are keyed by screen-facing side, while linking data is stored in world directions.
             var screenDirection = (direction.ToAngle() + eyeRotation).GetCardinalDir();
-            var connection = GetConnectionSuffix(screenDirection);
-            var statePrefix = state == RMCFoldingBarricadeLinkingVisualState.Open
-                ? "folding_plasteel_closed_connection"
-                : "folding_plasteel_connection";
+            if (!linking.TryGetConnectionState(screenDirection, state, out var stateId))
+            {
+                _sprite.LayerSetVisible(sprite, layerIndex, false);
+                continue;
+            }
 
-            _sprite.LayerSetRsiState(sprite, layerIndex, new StateId($"{statePrefix}_{connection}"));
+            _sprite.LayerSetRsiState(sprite, layerIndex, new StateId(stateId));
             _sprite.LayerSetVisible(sprite, layerIndex, true);
         }
     }
@@ -91,17 +95,5 @@ public sealed class RMCFoldingBarricadeLinkingVisualizerSystem : EntitySystem
     private Direction GetEyeDirection()
     {
         return _eye.CurrentEye.Rotation.GetCardinalDir();
-    }
-
-    private static int GetConnectionSuffix(Direction direction)
-    {
-        return direction switch
-        {
-            Direction.North => 1,
-            Direction.South => 2,
-            Direction.East => 4,
-            Direction.West => 8,
-            _ => 1,
-        };
     }
 }

--- a/Content.Shared/_RMC14/Entrenching/RMCFoldingBarricadeLinkingComponent.cs
+++ b/Content.Shared/_RMC14/Entrenching/RMCFoldingBarricadeLinkingComponent.cs
@@ -1,6 +1,7 @@
 using Content.Shared._RMC14.Marines.Skills;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
@@ -24,6 +25,27 @@ public sealed partial class RMCFoldingBarricadeLinkingComponent : Component
 
     [DataField]
     public SoundSpecifier? ToggleSound = new SoundPathSpecifier("/Audio/Items/crowbar.ogg");
+
+    [DataField]
+    public Dictionary<Direction, Dictionary<RMCFoldingBarricadeLinkingVisualState, string>> ConnectionStates = new();
+
+    [Access(Other = AccessPermissions.ReadExecute)]
+    public bool TryGetConnectionState(
+        Direction direction,
+        RMCFoldingBarricadeLinkingVisualState visualState,
+        out string state)
+    {
+        state = string.Empty;
+        if (!ConnectionStates.TryGetValue(direction, out var states) ||
+            !states.TryGetValue(visualState, out var foundState) ||
+            foundState == null)
+        {
+            return false;
+        }
+
+        state = foundState;
+        return true;
+    }
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/Barricades/barricade_plasteel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/Barricades/barricade_plasteel.yml
@@ -200,6 +200,19 @@
   # Stories-end
   - type: RMCFoldingBarricadeLinking
     linkable: true
+    connectionStates:
+      North:
+        Closed: folding_plasteel_connection_1
+        Open: folding_plasteel_closed_connection_1
+      South:
+        Closed: folding_plasteel_connection_2
+        Open: folding_plasteel_closed_connection_2
+      East:
+        Closed: folding_plasteel_connection_4
+        Open: folding_plasteel_closed_connection_4
+      West:
+        Closed: folding_plasteel_connection_8
+        Open: folding_plasteel_closed_connection_8
   - type: RMCRepairable
     heal: 200
     skill: RMCSkillConstruction


### PR DESCRIPTION
## Описание PR
Исправляет отображение визуальных связей у складных пласталевых баррикад при повороте камеры.

Теперь соединения между баррикадами корректно отображаются на нужной стороне экрана независимо от текущей ориентации камеры.

## Причина / Баланс
Баланс не меняется. Это визуальный фикс: раньше при повернутой камере линк-слои складных пласталевых баррикад могли отображаться с неправильной стороны.

## Технические детали
Добавлен клиентский `RMCFoldingBarricadeLinkingVisualizerSystem`, который обновляет RSI state слоев соединений с учетом текущего поворота камеры.

## Медиа
Не требуется, PR исправляет небольшой визуальный баг.

## Требования
- [x] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [x] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение.
- [x] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями.

**Changelog (Список изменений)**
- fix: Исправлено отображение связей складных пласталевых баррикад при повороте камеры.