### PR TITLE
Вода тушит мобов при сопротивлении огню

### DIFF
--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Damage.Components;
 using Content.Server.Stunnable;
 using Content.Server.Temperature.Systems;
 using Content.Shared._RMC14.Atmos;
+using Content.Shared._RMC14.Water;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Projectile.Spit;
 using Content.Shared.ActionBlocker;
@@ -54,6 +55,7 @@ namespace Content.Server.Atmos.EntitySystems
         [Dependency] private readonly AudioSystem _audio = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly SharedRMCFlammableSystem _rmcFlammable = default!;
+        [Dependency] private readonly RMCWaterSystem _rmcWater = default!; // RMC14
         [Dependency] private readonly XenoSpitSystem _xenoSpit = default!;
         [Dependency] private readonly IPrototypeManager _prototype = default!;
 
@@ -279,11 +281,36 @@ namespace Content.Server.Atmos.EntitySystems
             if (args.Handled)
                 return;
 
+            // RMC14 use the normal stop-drop-roll resist before active water extinguishes.
+            var wasResisting = ent.Comp.Resisting;
             _rmcFlammable.DoStopDropRollAnimation(ent.Owner);
             Resist(ent, ent);
+            if (!wasResisting && ent.Comp.Resisting)
+                TryExtinguishWithWater(ent.Owner, ent.Comp);
+            // RMC14 end
+
             _xenoSpit.Resist(ent.Owner);
             args.Handled = true;
         }
+
+        // RMC14 water extinguishing helper. Active water reuses RMCWaterSystem.CanCollide so catwalk-covered
+        // water does not count.
+        private bool TryExtinguishWithWater(EntityUid uid, FlammableComponent flammable)
+        {
+            if (!CanWaterExtinguish(uid, flammable) || !_rmcWater.IsInWater(uid))
+                return false;
+
+            Extinguish(uid, flammable);
+            return true;
+        }
+
+        private bool CanWaterExtinguish(EntityUid uid, FlammableComponent flammable)
+        {
+            return !TerminatingOrDeleted(uid) &&
+                   flammable.OnFire &&
+                   flammable.CanExtinguish;
+        }
+        // RMC14 end
 
         public void UpdateAppearance(EntityUid uid, FlammableComponent? flammable = null, AppearanceComponent? appearance = null)
         {

--- a/Content.Shared/_RMC14/Water/RMCWaterSystem.cs
+++ b/Content.Shared/_RMC14/Water/RMCWaterSystem.cs
@@ -1,6 +1,8 @@
 ﻿using Content.Shared._RMC14.Map;
 using Content.Shared.NameModifier.EntitySystems;
 using Content.Shared.Whitelist;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._RMC14.Water;
@@ -10,6 +12,7 @@ public sealed class RMCWaterSystem : EntitySystem
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly EntityWhitelistSystem _entityWhitelist = default!;
     [Dependency] private readonly NameModifierSystem _nameModifier = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly RMCMapSystem _rmcMap = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
@@ -55,6 +58,43 @@ public sealed class RMCWaterSystem : EntitySystem
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Returns true for uncovered RMC water that should apply water contact effects.
+    /// </summary>
+    public bool IsActiveWater(EntityUid water, EntityUid user, RMCWaterComponent? component = null)
+    {
+        return IsActiveWater((water, component), user);
+    }
+
+    public bool IsActiveWater(Entity<RMCWaterComponent?> water, EntityUid user)
+    {
+        if (!Resolve(water, ref water.Comp, false))
+            return false;
+
+        return CanCollide(water, user);
+    }
+
+    /// <summary>
+    /// Checks current physics contacts for active RMC water.
+    /// </summary>
+    public bool IsInWater(EntityUid user, FixturesComponent? fixtures = null)
+    {
+        if (!Resolve(user, ref fixtures, false))
+            return false;
+
+        var contacts = _physics.GetContacts((user, fixtures));
+        while (contacts.MoveNext(out var contact))
+        {
+            if (!contact.IsTouching)
+                continue;
+
+            if (IsActiveWater(contact.OtherEnt(user), user))
+                return true;
+        }
+
+        return false;
     }
 
     public override void Update(float frameTime)


### PR DESCRIPTION
## О PR

Добавляет взаимодействие между сопротивлением огню и активной RMC-водой.

Горящие мобы, которые используют обычное сопротивление огню / stop-drop-roll, находясь в RMC-воде, теперь тушатся сразу после запуска стандартного действия сопротивления. Это соответствует поведению из основного CMSS13: люди и ксено сначала начинают катиться / сопротивляться, а затем вызывается `ExtinguishMob()`, если они находятся на речной воде.

## Почему / Баланс

**ПАРИТЕТ**. Вода теперь дает горящим мобам надежный способ потушить себя, но для этого всё ещё нужно использовать обычное действие сопротивления огню. Простое нахождение в воде или ходьба по ней не тушит огонь пассивно.

Закрытая вода не считается активной. Проверка использует существующую RMC-логику столкновения с водой, поэтому вода, закрытая мостиками / water cover, не засчитывается.

Поведение тайлового огня не меняется: огонь всё ещё может существовать на воде, а мобы всё ещё могут загореться от огня на водном тайле, пока не начнут сопротивляться.

## Технические детали

В `RMCWaterSystem` добавлены вспомогательные методы для проверки воды:

- `IsActiveWater(...)`
- `IsInWater(...)`

Эти методы переиспользуют `RMCWaterSystem.CanCollide`, поэтому существующее поведение RMC water cover сохраняется.

`FlammableSystem.OnResistFireAlert` теперь сохраняет стандартный RMC-поток сопротивления огню:

1. проиграть stop-drop-roll визуалы;
2. запустить обычный `Resist`;
3. если моб успешно начал сопротивляться и находится в активной RMC-воде, вызвать `Extinguish`.

## Медиа

Небольшое изменение, медиа не требуется.

## Требования
- [x] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [x] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение.
- [x] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями.

**Changelog**

- tweak: Горящие мобы теперь сразу тушатся при использовании сопротивления огню, если стоят в активной RMC-воде.