### PR TITLE
Изменения охотника

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
@@ -118,7 +118,7 @@
     plasmaCost: 20
     delay: 0
     moveDelayTime: 0.8
-    knockdownTime: 3
+    knockdownTime: 3.5
     leapSound: /Audio/_RMC14/Xeno/alien_pounce.ogg
     knockdownRequiresInvisibility: true
     unrootOnMelee: true

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
@@ -66,11 +66,14 @@
   - type: XenoClaws
     clawType: Sharp
   - type: MeleeWeapon
-    attackRate: 0.75
+    #attackRate: 0.75
     damage:
       groups:
-        Brute: 35
+        Brute: 30
   - type: Tackle
+    max: 5
+    stunMin: 3
+    stunMax: 4
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.7
     baseSprintSpeed: 5
@@ -114,8 +117,8 @@
   - type: XenoLeap
     plasmaCost: 20
     delay: 0
-    moveDelayTime: 1.5
-    knockdownTime: 5
+    moveDelayTime: 0.8
+    knockdownTime: 3
     leapSound: /Audio/_RMC14/Xeno/alien_pounce.ogg
     knockdownRequiresInvisibility: true
     unrootOnMelee: true
@@ -192,6 +195,10 @@
     damage:
       groups:
         Brute: 30
+  - type: Tackle
+    max: 6
+    stunMin: 2
+    stunMax: 3
   - type: MovementSpeedModifier
     baseWalkSpeed: 3
     baseSprintSpeed: 6


### PR DESCRIPTION
<!-- Руководство: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что было изменено? -->
- Скорость атаки охотника: 0.75 --> 1
- Уменьшение урона за удар: 35 --> 30 
- Длительность неподвижности охотника после успешного прыжка: 1.5 --> 0.8 
- Длительность оглушения морпехов от прыжка: 5 --> 3.5
- Уменьшение максимального кол-ва толчков  чтобы повалить морпеха: 6 --> 5
- Увеличение длительности стана за успешный толчок: 2-3 --> 3-4

## Причина / Баланс
<!-- Опишите, как это повлияет на игровой баланс, или объясните причину изменений. Укажите ссылки на связанные обсуждения или issues. -->
Люркер СЛИШКОМ рулеточный. Его не берут практически никогда, ведь ситуаций когда он полезен так же практически не существует.
Теперь шансы морпеха встать когда его толкает люркер минимальны (всё ещё есть). Раньше затолкать до стаминакрита на люрке было НЕРЕАЛЬНО.
Так же небольшая балансировка прыжка. Но это всё ещё рулетка, где морпех спокойно сможет встать если ему повезёт (за всё время стана люрк даст максимум 3 толчка) Время стана 3.5, а не просто 3, так как берём в учёт наши сервера с лагами, фризами, плюс после прыжка всё равно есть задержка импута.

## Технические детали
<!-- Краткое описание изменений в коде для упрощения ревью. -->
attackRate охотника был закомменчен. Добавлены stunMin, stunMax и max для охотника и его стрейна - вампира, что бы вампир не перенял изменений толчков охотника.

## Медиа
<!-- Прикрепите скриншоты или видео, если PR вносит визуальные или игровые изменения (одежда, предметы, механики и т.д.).
Мелкие фиксы/рефакторинг не требуют медиа. Медиафайлы могут быть использованы в отчетах о разработке проекта с указанием авторства. -->

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [X] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
<!-- Пояснение к пункту ниже, подтверждая этот пункт, вы не теряете авторские права. Вы всё ещё владеете своим оригинальным кодом/артом и можете использовать его в своих личных целях. Галочка означает лишь то, что вы передаете проекту Space Stories (и его администрации) неэксклюзивное право свободно использовать этот вклад в наших сборках и связанных проектах. -->
- [X] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.
<!-- Имейте в виду, что несоблюдение вышеуказанных требований может привести к закрытию вашего PR на усмотрение мейнтейнеров -->

**Changelog (Список изменений)**
<!-- Добавьте запись в Changelog, чтобы игроки узнали о новых функциях или изменениях, влияющих на геймплей.
Изменения для админов можно указать с тегом admin:
Изменения в коде, невидимые в игре, можно указать для других контрибьюторов с тегом code:
Обязательно ознакомьтесь с руководством по чейнджлогам.
Changelog должен начинаться с символа :cl:, чтобы бот распознал изменения и добавил их в игру. -->
:cl:
- tweak: 
- Увеличение скорости атаки охотника ( 0.75 -- > 1 ударов в сек)
- Уменьшение урона за удар охотника (35 --> 30 ед)
- Уменьшение длительности неподвижности охотника после прыжка ( 1.5 --> 0.8 сек)
- Уменьшение длительности стана морпехов от прыжка охотника (5 --> 3.5 сек)
- Уменьшение максимального кол-ва толчков  чтобы повалить морпеха (6 --> 5)
- Увеличение длительности стана за успешный толчок (поваливший морпеха) ( 2-3 --> 3-4 сек)
