### PR TITLE
Изменение М15 ОТ

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/ordnancecasings.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/ordnancecasings.yml
@@ -152,7 +152,6 @@
   - type: CMVocalizeTrigger
   - type: Tag
     tags:
-    - LauncherCompatibleGrenade
     - Grenade
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -301,7 +301,6 @@
   - type: Tag
     tags:
     - Grenade
-    - LauncherCompatibleGrenade
   - type: Ammo
   - type: ClusterLimitHits
   - type: CMExplosionEffect
@@ -322,7 +321,6 @@
   - type: Tag
     tags:
     - Grenade
-    - LauncherCompatibleGrenade
 
 - type: entity
   parent: CMGrenadeBase


### PR DESCRIPTION
## Описание PR
Удален компонент LauncherCompatibleGrenade отвечающий за возможность сложить гранаты M15 в гранатометы 

## Причина / Баланс
https://discord.com/channels/1175915376559792189/1511395191297282171

## Технические детали
Удален Компонент LauncherCompatibleGrenade у всех гранат M15 

## Медиа

## Требования
- [X] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [X] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
- [X] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.

**Changelog (Список изменений)**
:cl:
- remove: Удален компонент LauncherCompatibleGrenade у гранат M15
