### PR TITLE
Фикс Гранат М15 ОТ

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Misc/ordnancecasings.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Misc/ordnancecasings.yml
@@ -152,7 +152,6 @@
   - type: CMVocalizeTrigger
   - type: Tag
     tags:
-    - LauncherCompatibleGrenade
     - Grenade
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -301,7 +301,6 @@
   - type: Tag
     tags:
     - Grenade
-    - LauncherCompatibleGrenade
   - type: Ammo
   - type: ClusterLimitHits
   - type: CMExplosionEffect
@@ -322,7 +321,6 @@
   - type: Tag
     tags:
     - Grenade
-    - LauncherCompatibleGrenade
 
 - type: entity
   parent: CMGrenadeBase

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -300,7 +300,6 @@
       cluster-payload: !type:Container
   - type: Tag
     tags:
-    - LauncherCompatibleGrenade
     - Grenade
   - type: Ammo
   - type: ClusterLimitHits
@@ -321,7 +320,6 @@
     totalIntensity: 280
   - type: Tag
     tags:
-    - LauncherCompatibleGrenade
     - Grenade
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -300,6 +300,7 @@
       cluster-payload: !type:Container
   - type: Tag
     tags:
+    - LauncherCompatibleGrenade
     - Grenade
   - type: Ammo
   - type: ClusterLimitHits
@@ -320,6 +321,7 @@
     totalIntensity: 280
   - type: Tag
     tags:
+    - LauncherCompatibleGrenade
     - Grenade
 
 - type: entity


### PR DESCRIPTION
## Описание PR
Убирает возможность гранатам M15 быть в гранатометах

## Причина / Баланс
https://discord.com/channels/1175915376559792189/1511395191297282171

## Технические детали
Удаляет LauncherCompatibleGrenade у Гранат M15 

## Медиа

## Требования
- [X] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [X] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые 
- [X] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.

**Changelog**
:cl:
- remove: LauncherCompatibleGrenade у Гранат M15 

