### PR TITLE
Очередь печати оружия CAS

### DIFF
--- a/Content.Client/_RMC14/Dropship/Fabricator/DropshipFabricatorBui.cs
+++ b/Content.Client/_RMC14/Dropship/Fabricator/DropshipFabricatorBui.cs
@@ -83,10 +83,82 @@ public sealed class DropshipFabricatorBui : BoundUserInterface
         if (_window is not { Disposed: false })
             return;
 
-        if (EntMan.TryGetComponent(Owner, out DropshipFabricatorComponent? fabricator))
+        if (!EntMan.TryGetComponent(Owner, out DropshipFabricatorComponent? fabricator))
+            return;
+
+        _window.PointsLabel.Text = Loc.GetString("rmc-dropship-fabricator-points",
+            ("points", fabricator.Points));
+
+        if (fabricator.Printing is { } printing)
         {
-            _window.PointsLabel.Text = Loc.GetString("rmc-dropship-fabricator-points", 
-                ("points", fabricator.Points));
+            _window.CurrentLabel.SetMarkupPermissive(Loc.GetString("rmc-dropship-fabricator-current",
+                ("item", GetPrintableName(printing))));
         }
+        else
+        {
+            _window.CurrentLabel.SetMarkupPermissive(Loc.GetString("rmc-dropship-fabricator-idle"));
+        }
+
+        _window.QueueLabel.SetMarkupPermissive(Loc.GetString("rmc-dropship-fabricator-queue",
+            ("count", fabricator.Queue.Count),
+            ("max", fabricator.MaxQueue)));
+
+        _window.QueueContainer.DisposeAllChildren();
+        if (fabricator.Queue.Count == 0)
+        {
+            var empty = new Label
+            {
+                Text = Loc.GetString("rmc-dropship-fabricator-queue-empty"),
+                Margin = new Thickness(4, 2),
+                HorizontalExpand = true,
+            };
+            _window.QueueContainer.AddChild(empty);
+            return;
+        }
+
+        for (var i = 0; i < fabricator.Queue.Count; i++)
+        {
+            var entry = fabricator.Queue[i];
+            var index = i;
+
+            var label = new Label
+            {
+                Text = Loc.GetString("rmc-dropship-fabricator-queue-entry",
+                    ("position", i + 1),
+                    ("item", GetPrintableName(entry.Id)),
+                    ("cost", entry.Cost)),
+                Margin = new Thickness(4, 2),
+                HorizontalExpand = false,
+            };
+
+            var cancel = new Button
+            {
+                Text = Loc.GetString("rmc-dropship-fabricator-cancel"),
+                StyleClasses = { "OpenBoth" },
+                MinWidth = 90,
+            };
+            cancel.OnPressed += _ => SendPredictedMessage(new DropshipFabricatorCancelQueueMsg(index));
+
+            var container = new BoxContainer
+            {
+                Orientation = LayoutOrientation.Horizontal,
+                Margin = new Thickness(0, 2),
+                Children =
+                {
+                    label,
+                    new Control { HorizontalExpand = true },
+                    cancel
+                },
+                HorizontalExpand = true,
+            };
+            _window.QueueContainer.AddChild(container);
+        }
+    }
+
+    private string GetPrintableName(EntProtoId<DropshipFabricatorPrintableComponent> id)
+    {
+        return _prototypes.TryIndex(id, out var proto)
+            ? proto.Name
+            : id.ToString();
     }
 }

--- a/Content.Client/_RMC14/Dropship/Fabricator/DropshipFabricatorBui.cs
+++ b/Content.Client/_RMC14/Dropship/Fabricator/DropshipFabricatorBui.cs
@@ -12,6 +12,8 @@ namespace Content.Client._RMC14.Dropship.Fabricator;
 [UsedImplicitly]
 public sealed class DropshipFabricatorBui : BoundUserInterface
 {
+    private const int QueueRowHeight = 28;
+
     [Dependency] private readonly IComponentFactory _compFactory = default!;
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
 
@@ -111,6 +113,7 @@ public sealed class DropshipFabricatorBui : BoundUserInterface
                 Text = Loc.GetString("rmc-dropship-fabricator-queue-empty"),
                 Margin = new Thickness(4, 2),
                 HorizontalExpand = true,
+                SetHeight = QueueRowHeight,
             };
             _window.QueueContainer.AddChild(empty);
             return;
@@ -129,6 +132,7 @@ public sealed class DropshipFabricatorBui : BoundUserInterface
                     ("cost", entry.Cost)),
                 Margin = new Thickness(4, 2),
                 HorizontalExpand = false,
+                VerticalAlignment = Control.VAlignment.Center,
             };
 
             var cancel = new Button
@@ -136,6 +140,7 @@ public sealed class DropshipFabricatorBui : BoundUserInterface
                 Text = Loc.GetString("rmc-dropship-fabricator-cancel"),
                 StyleClasses = { "OpenBoth" },
                 MinWidth = 90,
+                SetHeight = 24,
             };
             cancel.OnPressed += _ => SendPredictedMessage(new DropshipFabricatorCancelQueueMsg(index));
 
@@ -150,6 +155,7 @@ public sealed class DropshipFabricatorBui : BoundUserInterface
                     cancel
                 },
                 HorizontalExpand = true,
+                SetHeight = QueueRowHeight,
             };
             _window.QueueContainer.AddChild(container);
         }

--- a/Content.Client/_RMC14/Dropship/Fabricator/DropshipFabricatorWindow.xaml
+++ b/Content.Client/_RMC14/Dropship/Fabricator/DropshipFabricatorWindow.xaml
@@ -23,6 +23,11 @@
                 <BoxContainer Orientation="Vertical" Margin="4">
                     <RichTextLabel Text="{Loc 'rmc-dropship-fabricator-title'}" HorizontalAlignment="Center" />
                     <Label Name="PointsLabel" Access="Public" Margin="4 2" HorizontalAlignment="Center" />
+                    <ui:BlueHorizontalSeparator />
+                    <RichTextLabel Name="CurrentLabel" Access="Public" Margin="4 2" />
+                    <RichTextLabel Name="QueueLabel" Access="Public" Margin="4 2 4 0" />
+                    <BoxContainer Name="QueueContainer" Access="Public" Orientation="Vertical"
+                                  HorizontalExpand="True" />
                 </BoxContainer>
             </PanelContainer>
             <BoxContainer Orientation="Horizontal" HorizontalExpand="True" VerticalExpand="True">

--- a/Content.Client/_RMC14/Dropship/Fabricator/DropshipFabricatorWindow.xaml
+++ b/Content.Client/_RMC14/Dropship/Fabricator/DropshipFabricatorWindow.xaml
@@ -4,7 +4,8 @@
     xmlns:ui="clr-namespace:Content.Client._RMC14.UserInterface"
     xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
     Title="{Loc 'rmc-dropship-fabricator-title'}"
-    MinSize="950 450">
+    MinSize="950 570"
+    SetSize="950 570">
     <PanelContainer>
         <PanelContainer.PanelOverride>
             <graphics:StyleBoxFlat 
@@ -26,8 +27,11 @@
                     <ui:BlueHorizontalSeparator />
                     <RichTextLabel Name="CurrentLabel" Access="Public" Margin="4 2" />
                     <RichTextLabel Name="QueueLabel" Access="Public" Margin="4 2 4 0" />
-                    <BoxContainer Name="QueueContainer" Access="Public" Orientation="Vertical"
-                                  HorizontalExpand="True" />
+                    <ScrollContainer HScrollEnabled="False" VScrollEnabled="True"
+                                     HorizontalExpand="True" MinHeight="84" MaxHeight="84" SetHeight="84">
+                        <BoxContainer Name="QueueContainer" Access="Public" Orientation="Vertical"
+                                      HorizontalExpand="True" />
+                    </ScrollContainer>
                 </BoxContainer>
             </PanelContainer>
             <BoxContainer Orientation="Horizontal" HorizontalExpand="True" VerticalExpand="True">

--- a/Content.Shared/_RMC14/Dropship/Fabricator/DropshipFabricatorComponent.cs
+++ b/Content.Shared/_RMC14/Dropship/Fabricator/DropshipFabricatorComponent.cs
@@ -1,6 +1,7 @@
 ﻿using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._RMC14.Dropship.Fabricator;
@@ -18,6 +19,12 @@ public sealed partial class DropshipFabricatorComponent : Component
     [DataField, AutoNetworkedField]
     public EntProtoId<DropshipFabricatorPrintableComponent>? Printing;
 
+    [DataField, AutoNetworkedField]
+    public List<DropshipFabricatorQueueEntry> Queue = new();
+
+    [DataField, AutoNetworkedField]
+    public int MaxQueue = 6;
+
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan PrintAt;
 
@@ -26,4 +33,24 @@ public sealed partial class DropshipFabricatorComponent : Component
 
     [DataField, AutoNetworkedField]
     public SoundSpecifier RecycleSound = new SoundPathSpecifier("/Audio/_RMC14/Machines/fax.ogg");
+}
+
+[DataDefinition, Serializable, NetSerializable]
+public sealed partial class DropshipFabricatorQueueEntry
+{
+    [DataField]
+    public EntProtoId<DropshipFabricatorPrintableComponent> Id;
+
+    [DataField]
+    public int Cost;
+
+    public DropshipFabricatorQueueEntry()
+    {
+    }
+
+    public DropshipFabricatorQueueEntry(EntProtoId<DropshipFabricatorPrintableComponent> id, int cost)
+    {
+        Id = id;
+        Cost = cost;
+    }
 }

--- a/Content.Shared/_RMC14/Dropship/Fabricator/DropshipFabricatorSystem.cs
+++ b/Content.Shared/_RMC14/Dropship/Fabricator/DropshipFabricatorSystem.cs
@@ -46,6 +46,7 @@ public sealed class DropshipFabricatorSystem : EntitySystem
             subs =>
             {
                 subs.Event<DropshipFabricatorPrintMsg>(OnPrintMsg);
+                subs.Event<DropshipFabricatorCancelQueueMsg>(OnCancelQueueMsg);
             });
 
         Subs.CVar(_config, RMCCVars.RMCDropshipFabricatorStartingPoints, v => _startingPoints = v, true);
@@ -85,6 +86,7 @@ public sealed class DropshipFabricatorSystem : EntitySystem
 
         points.Points += (int) (refund * printable.RecycleMultiplier);
         Dirty(ent.Comp.Account.Value, points);
+        SendUIStateAll(points.Points);
         Del(args.Used);
 
         _audio.PlayPvs(ent.Comp.RecycleSound, ent);
@@ -100,27 +102,89 @@ public sealed class DropshipFabricatorSystem : EntitySystem
             return;
 
         var actor = args.Actor;
-        if (ent.Comp.Printing != null)
-        {
-            _popup.PopupClient(Loc.GetString("rmc-dropship-fabricator-busy"), actor, actor, PopupType.SmallCaution);
-            return;
-        }
-
         if (!TryComp(ent.Comp.Account, out DropshipFabricatorPointsComponent? points))
             return;
 
-        if (printable.Cost > points.Points)
+        if (ent.Comp.Queue.Count >= ent.Comp.MaxQueue)
+        {
+            _popup.PopupClient(Loc.GetString("rmc-dropship-fabricator-queue-full"), actor, actor, PopupType.SmallCaution);
             return;
+        }
+
+        if (printable.Cost > points.Points)
+        {
+            _popup.PopupClient(Loc.GetString("rmc-dropship-fabricator-insufficient-points"), actor, actor, PopupType.SmallCaution);
+            return;
+        }
 
         points.Points -= printable.Cost;
         Dirty(ent.Comp.Account.Value, points);
+        SendUIStateAll(points.Points);
 
-        ent.Comp.Points = points.Points;
-        ent.Comp.Printing = proto.ID;
-        ent.Comp.PrintAt = _timing.CurTime + printable.Delay;
+        ent.Comp.Queue.Add(new DropshipFabricatorQueueEntry(proto.ID, printable.Cost));
         Dirty(ent);
+        TryStartNextPrint(ent);
+    }
 
-        _appearance.SetData(ent, DropshipFabricatorVisuals.State, DropshipFabricatorState.Fabricating);
+    private void OnCancelQueueMsg(Entity<DropshipFabricatorComponent> ent, ref DropshipFabricatorCancelQueueMsg args)
+    {
+        if (args.Index < 0 || args.Index >= ent.Comp.Queue.Count)
+            return;
+
+        var entry = ent.Comp.Queue[args.Index];
+        ent.Comp.Queue.RemoveAt(args.Index);
+
+        if (TryComp(ent.Comp.Account, out DropshipFabricatorPointsComponent? points))
+        {
+            points.Points += entry.Cost;
+            Dirty(ent.Comp.Account.Value, points);
+            SendUIStateAll(points.Points);
+        }
+
+        Dirty(ent);
+    }
+
+    private bool TryStartNextPrint(Entity<DropshipFabricatorComponent> ent)
+    {
+        if (ent.Comp.Printing != null)
+            return false;
+
+        var changed = false;
+        while (ent.Comp.Queue.Count > 0)
+        {
+            changed = true;
+            var entry = ent.Comp.Queue[0];
+            ent.Comp.Queue.RemoveAt(0);
+
+            if (!_prototypes.TryIndex(entry.Id, out var proto) ||
+                !proto.TryGetComponent(out DropshipFabricatorPrintableComponent? printable, _compFactory))
+            {
+                RefundQueuedCost(ent, entry.Cost);
+                continue;
+            }
+
+            ent.Comp.Printing = entry.Id;
+            ent.Comp.PrintAt = _timing.CurTime + printable.Delay;
+            Dirty(ent);
+
+            _appearance.SetData(ent, DropshipFabricatorVisuals.State, DropshipFabricatorState.Fabricating);
+            return true;
+        }
+
+        if (changed)
+            Dirty(ent);
+
+        return false;
+    }
+
+    private void RefundQueuedCost(Entity<DropshipFabricatorComponent> ent, int cost)
+    {
+        if (!TryComp(ent.Comp.Account, out DropshipFabricatorPointsComponent? points))
+            return;
+
+        points.Points += cost;
+        Dirty(ent.Comp.Account.Value, points);
+        SendUIStateAll(points.Points);
     }
 
     private Entity<DropshipFabricatorPointsComponent> EnsurePoints()
@@ -181,10 +245,13 @@ public sealed class DropshipFabricatorSystem : EntitySystem
         var allFabricatorQuery = EntityQueryEnumerator<DropshipFabricatorComponent, TransformComponent>();
         while (allFabricatorQuery.MoveNext(out var uid, out var comp, out var xform))
         {
-            if (time < comp.PrintAt)
-                continue;
-
             if (comp.Printing == null)
+            {
+                TryStartNextPrint((uid, comp));
+                continue;
+            }
+
+            if (time < comp.PrintAt)
                 continue;
 
             var rotation = _transform.GetWorldRotation(xform);
@@ -194,7 +261,8 @@ public sealed class DropshipFabricatorSystem : EntitySystem
             comp.Printing = null;
             Dirty(uid, comp);
 
-            _appearance.SetData(uid, DropshipFabricatorVisuals.State, DropshipFabricatorState.Idle);
+            if (!TryStartNextPrint((uid, comp)))
+                _appearance.SetData(uid, DropshipFabricatorVisuals.State, DropshipFabricatorState.Idle);
         }
 
         var pointsQuery = EntityQueryEnumerator<DropshipFabricatorPointsComponent>();

--- a/Content.Shared/_RMC14/Dropship/Fabricator/DropshipFabricatorUi.cs
+++ b/Content.Shared/_RMC14/Dropship/Fabricator/DropshipFabricatorUi.cs
@@ -14,3 +14,9 @@ public sealed class DropshipFabricatorPrintMsg(EntProtoId id) : BoundUserInterfa
 {
     public readonly EntProtoId Id = id;
 }
+
+[Serializable, NetSerializable]
+public sealed class DropshipFabricatorCancelQueueMsg(int index) : BoundUserInterfaceMessage
+{
+    public readonly int Index = index;
+}

--- a/Resources/Locale/en-US/_RMC14/dropship/rmc-dropship.ftl
+++ b/Resources/Locale/en-US/_RMC14/dropship/rmc-dropship.ftl
@@ -108,6 +108,14 @@ rmc-dropship-fabricator-equipment = [bold]Equipment[/bold]
 rmc-dropship-fabricator-ammo = [bold]Ammo[/bold]
 rmc-dropship-fabricator-fabricate = Fabricate ({$cost})
 rmc-dropship-fabricator-busy = The dropship part fabricator is busy. Please wait for completion of previous operation.
+rmc-dropship-fabricator-current = [bold]Current:[/bold] {$item}
+rmc-dropship-fabricator-idle = [bold]Current:[/bold] Idle
+rmc-dropship-fabricator-queue = [bold]Queue:[/bold] {$count}/{$max}
+rmc-dropship-fabricator-queue-empty = No pending orders.
+rmc-dropship-fabricator-queue-entry = {$position}. {$item} ({$cost})
+rmc-dropship-fabricator-cancel = Cancel
+rmc-dropship-fabricator-queue-full = The dropship part fabricator queue is full.
+rmc-dropship-fabricator-insufficient-points = You don't have enough points to fabricate that.
 
 rmc-dropship-firemission-warning = A DROPSHIP FIRES TOWARDS THE {$direction}
 rmc-dropship-firemission-warning-above = A DROPSHIP FIRES RIGHT ONTOP OF YOU!

--- a/Resources/Locale/ru-RU/_RMC14/dropship/rmc-dropship.ftl
+++ b/Resources/Locale/ru-RU/_RMC14/dropship/rmc-dropship.ftl
@@ -103,6 +103,14 @@ rmc-dropship-fabricator-equipment = [bold]Снаряжение[/bold]
 rmc-dropship-fabricator-ammo = [bold]Патроны[/bold]
 rmc-dropship-fabricator-fabricate = Изготовить ({ $cost })
 rmc-dropship-fabricator-busy = Изготовитель деталей для дропшиппинга занят. Пожалуйста, подождите завершения предыдущей операции.
+rmc-dropship-fabricator-current = [bold]Сейчас:[/bold] { $item }
+rmc-dropship-fabricator-idle = [bold]Сейчас:[/bold] ожидание
+rmc-dropship-fabricator-queue = [bold]Очередь:[/bold] { $count }/{ $max }
+rmc-dropship-fabricator-queue-empty = Нет ожидающих заказов.
+rmc-dropship-fabricator-queue-entry = { $position }. { $item } ({ $cost })
+rmc-dropship-fabricator-cancel = Отмена
+rmc-dropship-fabricator-queue-full = Очередь изготовителя деталей десантного корабля заполнена.
+rmc-dropship-fabricator-insufficient-points = У вас недостаточно очков для изготовления.
 
 rmc-dropship-firemission-warning = Десантный корабль ведет огонь в направлении { $direction }.
 rmc-dropship-firemission-warning-above = Десантный корабль ведет огонь прямо над вами!


### PR DESCRIPTION
## О PR
Добавляет очередь ожидающей печати для фабрикатора деталей дропшипа. Теперь игроки могут заказать несколько CAS-орудий, ракет, боеприпасов и других предметов фабрикатора дропшипа, пока другой предмет уже печатается.

## Почему / Баланс
Это приближает фабрикатор к поведению CMSS13 и убирает необходимость ждать у консоли каждую отдельную печать. Очки всё ещё тратятся в момент добавления предмета в очередь, поэтому это не позволяет бесплатно заказывать слишком много предметов. Ожидающие заказы можно отменить с возвратом очков, но текущий печатающийся предмет отменить нельзя.

## Технические детали
Добавлены `DropshipFabricatorQueueEntry` и синхронизируемый по сети список `Queue` в `DropshipFabricatorComponent`, а также `MaxQueue = 6`, чтобы соответствовать существующему лимиту очереди lathe/autolathe.

`DropshipFabricatorSystem` теперь проверяет печатаемые прототипы, вместимость очереди, общий счёт очков фабрикатора дропшипа, сразу резервирует стоимость и добавляет предмет в ожидающую очередь. Если фабрикатор простаивает, `TryStartNextPrint` удаляет первую ожидающую запись, устанавливает существующее поле `Printing`, обновляет `PrintAt` и переключает внешний вид фабрикатора в состояние печати.

Когда `Update` завершает активную печать предмета из `Printing`, он создаёт прототип на существующем смещении фабрикатора, очищает `Printing` и сразу пытается запустить следующий предмет из очереди. Если записей больше нет, фабрикатор возвращается в состояние простоя. Некорректные прототипы в очереди пропускаются, а их зарезервированная стоимость возвращается.

Добавлен `DropshipFabricatorCancelQueueMsg` для отмены ожидающих записей по индексу. Отмена удаляет ожидающую запись, возвращает её сохранённую стоимость на общий счёт очков и помечает все фабрикаторы как изменённые, чтобы открытые интерфейсы обновились. Активный предмет в `Printing` по-прежнему нельзя отменить.

Клиентский BUI по-прежнему использует существующий путь авто-синхронизации компонента через `DropshipFabricatorUISystem`. `DropshipFabricatorBui.Refresh()` теперь напрямую читает `Printing`, `Queue`, `Points` и `MaxQueue` из `DropshipFabricatorComponent`, после чего перерисовывает строку текущей работы и строки ожидающей очереди с кнопками отмены. Существующие кнопки печати Equipment и Ammo не изменены.

Добавлены строки локализации для текущей работы, состояния простоя, количества предметов в очереди, пустой очереди, записей очереди, отмены, полной очереди и недостатка очков.

## Медиа
<img width="1197" height="395" alt="image" src="https://github.com/user-attachments/assets/44a82e52-4130-49d3-9bd1-40398b652776" />

## Требования
- [X] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [X] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
- [X] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.

**Changelog**
- add: Добавлена очередь для фабрикатора деталей дропшипа.