### PR TITLE
Увеличен объем буфера хим-мастера до 500 единиц

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Science/chem_master.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Science/chem_master.yml
@@ -97,7 +97,7 @@
   - type: SolutionContainerManager
     solutions:
       buffer:
-        maxVol: 300 # Stories-Parity
+        maxVol: 500
   - type: RMCChemMaster
     pillBottleWhitelist:
       tags:


### PR DESCRIPTION
## Описание PR
Объем внутреннего буфера для хранения химических веществ в аппарате ChemMaster 3000 (и его промышленная версии) увеличен с 300 до 500 единиц.

## Причина / Баланс
Текущего объема буфера в 300 единиц часто не хватает для создания полной таблетницы из за чего приходится делать это дважды. Увеличение объема до 500 юнитов сделает работу мед отдела более комфортной, так же надеюсь что мед отдел решится делать таблетки.

## Технические детали
MaxVol в хим мастере был изменен с 300 до 500 унций.

## Медиа
## Требования
- [X] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [X] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
- [X] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.

**Changelog (Список изменений)**
:cl:
- tweak: Объем внутреннего буфера хим-мастера увеличен с 300 до 500 единиц.