### PR TITLE
Добавление консоли возврата имущества в Карго

### DIFF
--- a/Resources/Maps/_Stories/almayer.yml
+++ b/Resources/Maps/_Stories/almayer.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 264.0.2-fix-physics
+  engineVersion: 264.0.2
   forkId: ""
   forkVersion: ""
-  time: 05/31/2026 21:50:21
-  entityCount: 28026
+  time: 06/09/2026 17:17:21
+  entityCount: 28025
 maps:
 - 1
 grids:
@@ -30114,6 +30114,7 @@ entities:
         125,56: RMCAreaAlmayerCommandAiroom
         126,48: RMCAreaAlmayerCommandAiroom
         123,48: RMCAreaAlmayerCommandAiroom
+    - type: RadiationGridResistance
 - proto: AirAlarm
   entities:
   - uid: 6
@@ -58025,7 +58026,7 @@ entities:
     - type: CMDoubleDoor
       lastOpeningAt: 10761.05
     - type: Door
-      secondsUntilStateChange: -137532.94
+      secondsUntilStateChange: -137564.5
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -58049,7 +58050,7 @@ entities:
     - type: CMDoubleDoor
       lastOpeningAt: 10761.05
     - type: Door
-      secondsUntilStateChange: -137532.94
+      secondsUntilStateChange: -137564.5
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -67975,134 +67976,184 @@ entities:
     - type: Transform
       pos: 5.5,33.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6899
     components:
     - type: Transform
       pos: -52.5,90.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6900
     components:
     - type: Transform
       pos: -52.5,107.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6901
     components:
     - type: Transform
       pos: 57.5,108.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6902
     components:
     - type: Transform
       pos: 60.5,3.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6903
     components:
     - type: Transform
       pos: 6.5,-28.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6904
     components:
     - type: Transform
       pos: 5.5,-28.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6905
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-30.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6906
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-30.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6907
     components:
     - type: Transform
       pos: 6.5,33.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6908
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,31.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6909
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,31.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6910
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -66.5,114.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6911
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -119.5,97.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6912
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -119.5,96.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6913
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,83.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6914
     components:
     - type: Transform
       pos: 83.5,90.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6915
     components:
     - type: Transform
       pos: 84.5,90.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6916
     components:
     - type: Transform
       pos: 63.5,128.75
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6917
     components:
     - type: Transform
       pos: -5.5,104.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6918
     components:
     - type: Transform
       pos: -3.5,104.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6919
     components:
     - type: Transform
       pos: -4.5,104.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6920
     components:
     - type: Transform
       pos: 58.5,108.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6921
     components:
     - type: Transform
       pos: -102.5,6.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 6922
     components:
     - type: Transform
       pos: -100.5,6.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: CMSink
   entities:
   - uid: 6923
@@ -131028,38 +131079,6 @@ entities:
     - type: Transform
       pos: -44.5,-17.5
       parent: 1
-- proto: RMCBeakerHighCapacity
-  entities:
-  - uid: 18413
-    components:
-    - type: Transform
-      pos: -38.5,5.5
-      parent: 1
-  - uid: 18414
-    components:
-    - type: Transform
-      pos: -42.5,5.5
-      parent: 1
-  - uid: 18415
-    components:
-    - type: Transform
-      pos: -34.51414,-21.297161
-      parent: 1
-  - uid: 18416
-    components:
-    - type: Transform
-      pos: -34.51414,-21.64115
-      parent: 1
-  - uid: 18417
-    components:
-    - type: Transform
-      pos: -31.264141,-20.546638
-      parent: 1
-  - uid: 18418
-    components:
-    - type: Transform
-      pos: -31.576641,-20.192226
-      parent: 1
 - proto: RMCBible
   entities:
   - uid: 18419
@@ -132246,6 +132265,8 @@ entities:
     - type: Transform
       pos: -16.5,97.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: RMCCatwalkHybrisaLattice
   entities:
   - uid: 18632
@@ -141552,6 +141573,14 @@ entities:
     - type: Transform
       pos: -3.7624526,-17.678335
       parent: 1
+- proto: RMCCryoRecoveryConsole
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 33.5,-8.5
+      parent: 1
 - proto: RMCCurtainMedical
   entities:
   - uid: 20367
@@ -141671,7 +141700,7 @@ entities:
       pos: 71.5,-14.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -284120.44
+      secondsUntilStateChange: -284152
       state: Opening
   - uid: 20388
     components:
@@ -141679,7 +141708,7 @@ entities:
       pos: 72.5,-14.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -284120
+      secondsUntilStateChange: -284151.56
       state: Opening
   - uid: 20389
     components:
@@ -141687,7 +141716,7 @@ entities:
       pos: 73.5,-14.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -284119.6
+      secondsUntilStateChange: -284151.16
       state: Opening
   - uid: 20390
     components:
@@ -141695,7 +141724,7 @@ entities:
       pos: 71.5,13.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -284114.06
+      secondsUntilStateChange: -284145.62
       state: Opening
   - uid: 20391
     components:
@@ -141703,7 +141732,7 @@ entities:
       pos: 72.5,13.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -284114.47
+      secondsUntilStateChange: -284146.03
       state: Opening
   - uid: 20392
     components:
@@ -141711,7 +141740,7 @@ entities:
       pos: 73.5,13.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -284114.88
+      secondsUntilStateChange: -284146.44
       state: Opening
   - uid: 20393
     components:
@@ -141721,7 +141750,7 @@ entities:
       pos: 11.5,91.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -16660.709
+      secondsUntilStateChange: -16692.268
       state: Opening
   - uid: 20394
     components:
@@ -171960,6 +171989,8 @@ entities:
     - type: Transform
       pos: 6.5,-32.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: RMCGogglesBallistic
   entities:
   - uid: 23567
@@ -172310,29 +172341,449 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -118.5,103.5
       parent: 1
+    - type: IdModificationConsole
+      jobList:
+      - MessTech
+      - CMP
+      - ASO
+      - Rifleman
+      - Researcher
+      - CMCE
+      - Synth
+      - SO
+      - WeaponSpec
+      - SmartGunOperator
+      - CMWarden
+      - HospitalCorpsman
+      - MP
+      - RMCFieldDoctor
+      - MaintTech
+      - CMCMO
+      - IntelOfficer
+      - OT
+      - CO
+      - Nurse
+      - CombatTech
+      - MarineMain
+      - FTL
+      - QuarterMaster
+      - Pilot
+      - DropshipCrewChief
+      - SquadLeader
+      - SEA
+      - RMCWeYaExec
+      - CMCargoTech
+      - CMMedbay
+      jobGroups:
+      - RMCBaseMiscellaneousJob
+      - RMCBaseMarinesJob
+      - RMCBaseRequisitionsJob
+      - RMCBaseMPJob
+      - RMCBaseEngineeringJob
+      - RMCBaseMedicalJob
+      - RMCBaseAuxiliaryJob
+      - RMCBaseCommandJob
+      accessList:
+      - CMAccessSpecPrep
+      - CMAccessKitchen
+      - RMCAccessDatabase
+      - CMAccessBrig
+      - CMAccessSmartPrep
+      - CMAccessOT
+      - CMAccessCMP
+      - CMAccessCombatTechPrep
+      - RMCAccessFieldDoctor
+      - CMAccessDropship
+      - CMAccessSquadLeaderPrep
+      - CMAccessQM
+      - CMAccessChemistry
+      - CMAccessCharlie
+      - CMAccessBravo
+      - CMAccessEngineering
+      - RMCAccessLogs
+      - RMCAccessSeniorCommand
+      - CMAccessMaint
+      - CMAccessDelta
+      - CMAccessFTLPrep
+      - CMAccessCMO
+      - CMAccessMedical
+      - CMAccessAlpha
+      - CMAccessMarineRifleman
+      - RMCAccessMorgue
+      - CMAccessArmory
+      - RMCAccessCommand
+      - CMAccessMedPrep
+      - CMAccessRequisitions
+      - CMAccessMarinePrep
+      - CMAccessResearch
+      - CMAccessCE
+      accessGroups:
+      - RMCBaseARESAccess
+      - RMCBaseMarineAccess
+      - RMCBaseMPAccess
+      - RMCBaseSquadAccess
+      - RMCBaseMedicalAccess
+      - RMCBaseCommandAccess
+      - RMCBaseEngineeringAccess
   - uid: 23601
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -47,99
       parent: 1
+    - type: IdModificationConsole
+      jobList:
+      - MessTech
+      - CMP
+      - ASO
+      - Rifleman
+      - Researcher
+      - CMCE
+      - Synth
+      - SO
+      - WeaponSpec
+      - SmartGunOperator
+      - CMWarden
+      - HospitalCorpsman
+      - MP
+      - RMCFieldDoctor
+      - MaintTech
+      - CMCMO
+      - IntelOfficer
+      - OT
+      - CO
+      - Nurse
+      - CombatTech
+      - MarineMain
+      - FTL
+      - QuarterMaster
+      - Pilot
+      - DropshipCrewChief
+      - SquadLeader
+      - SEA
+      - RMCWeYaExec
+      - CMCargoTech
+      - CMMedbay
+      jobGroups:
+      - RMCBaseMiscellaneousJob
+      - RMCBaseMarinesJob
+      - RMCBaseRequisitionsJob
+      - RMCBaseMPJob
+      - RMCBaseEngineeringJob
+      - RMCBaseMedicalJob
+      - RMCBaseAuxiliaryJob
+      - RMCBaseCommandJob
+      accessList:
+      - CMAccessSpecPrep
+      - CMAccessKitchen
+      - RMCAccessDatabase
+      - CMAccessBrig
+      - CMAccessSmartPrep
+      - CMAccessOT
+      - CMAccessCMP
+      - CMAccessCombatTechPrep
+      - RMCAccessFieldDoctor
+      - CMAccessDropship
+      - CMAccessSquadLeaderPrep
+      - CMAccessQM
+      - CMAccessChemistry
+      - CMAccessCharlie
+      - CMAccessBravo
+      - CMAccessEngineering
+      - RMCAccessLogs
+      - RMCAccessSeniorCommand
+      - CMAccessMaint
+      - CMAccessDelta
+      - CMAccessFTLPrep
+      - CMAccessCMO
+      - CMAccessMedical
+      - CMAccessAlpha
+      - CMAccessMarineRifleman
+      - RMCAccessMorgue
+      - CMAccessArmory
+      - RMCAccessCommand
+      - CMAccessMedPrep
+      - CMAccessRequisitions
+      - CMAccessMarinePrep
+      - CMAccessResearch
+      - CMAccessCE
+      accessGroups:
+      - RMCBaseARESAccess
+      - RMCBaseMarineAccess
+      - RMCBaseMPAccess
+      - RMCBaseSquadAccess
+      - RMCBaseMedicalAccess
+      - RMCBaseCommandAccess
+      - RMCBaseEngineeringAccess
   - uid: 23602
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -63.5,119.5
       parent: 1
+    - type: IdModificationConsole
+      jobList:
+      - MessTech
+      - CMP
+      - ASO
+      - Rifleman
+      - Researcher
+      - CMCE
+      - Synth
+      - SO
+      - WeaponSpec
+      - SmartGunOperator
+      - CMWarden
+      - HospitalCorpsman
+      - MP
+      - RMCFieldDoctor
+      - MaintTech
+      - CMCMO
+      - IntelOfficer
+      - OT
+      - CO
+      - Nurse
+      - CombatTech
+      - MarineMain
+      - FTL
+      - QuarterMaster
+      - Pilot
+      - DropshipCrewChief
+      - SquadLeader
+      - SEA
+      - RMCWeYaExec
+      - CMCargoTech
+      - CMMedbay
+      jobGroups:
+      - RMCBaseMiscellaneousJob
+      - RMCBaseMarinesJob
+      - RMCBaseRequisitionsJob
+      - RMCBaseMPJob
+      - RMCBaseEngineeringJob
+      - RMCBaseMedicalJob
+      - RMCBaseAuxiliaryJob
+      - RMCBaseCommandJob
+      accessList:
+      - CMAccessSpecPrep
+      - CMAccessKitchen
+      - RMCAccessDatabase
+      - CMAccessBrig
+      - CMAccessSmartPrep
+      - CMAccessOT
+      - CMAccessCMP
+      - CMAccessCombatTechPrep
+      - RMCAccessFieldDoctor
+      - CMAccessDropship
+      - CMAccessSquadLeaderPrep
+      - CMAccessQM
+      - CMAccessChemistry
+      - CMAccessCharlie
+      - CMAccessBravo
+      - CMAccessEngineering
+      - RMCAccessLogs
+      - RMCAccessSeniorCommand
+      - CMAccessMaint
+      - CMAccessDelta
+      - CMAccessFTLPrep
+      - CMAccessCMO
+      - CMAccessMedical
+      - CMAccessAlpha
+      - CMAccessMarineRifleman
+      - RMCAccessMorgue
+      - CMAccessArmory
+      - RMCAccessCommand
+      - CMAccessMedPrep
+      - CMAccessRequisitions
+      - CMAccessMarinePrep
+      - CMAccessResearch
+      - CMAccessCE
+      accessGroups:
+      - RMCBaseARESAccess
+      - RMCBaseMarineAccess
+      - RMCBaseMPAccess
+      - RMCBaseSquadAccess
+      - RMCBaseMedicalAccess
+      - RMCBaseCommandAccess
+      - RMCBaseEngineeringAccess
   - uid: 23603
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -65.5,98.5
       parent: 1
+    - type: IdModificationConsole
+      jobList:
+      - MessTech
+      - CMP
+      - ASO
+      - Rifleman
+      - Researcher
+      - CMCE
+      - Synth
+      - SO
+      - WeaponSpec
+      - SmartGunOperator
+      - CMWarden
+      - HospitalCorpsman
+      - MP
+      - RMCFieldDoctor
+      - MaintTech
+      - CMCMO
+      - IntelOfficer
+      - OT
+      - CO
+      - Nurse
+      - CombatTech
+      - MarineMain
+      - FTL
+      - QuarterMaster
+      - Pilot
+      - DropshipCrewChief
+      - SquadLeader
+      - SEA
+      - RMCWeYaExec
+      - CMCargoTech
+      - CMMedbay
+      jobGroups:
+      - RMCBaseMiscellaneousJob
+      - RMCBaseMarinesJob
+      - RMCBaseRequisitionsJob
+      - RMCBaseMPJob
+      - RMCBaseEngineeringJob
+      - RMCBaseMedicalJob
+      - RMCBaseAuxiliaryJob
+      - RMCBaseCommandJob
+      accessList:
+      - CMAccessSpecPrep
+      - CMAccessKitchen
+      - RMCAccessDatabase
+      - CMAccessBrig
+      - CMAccessSmartPrep
+      - CMAccessOT
+      - CMAccessCMP
+      - CMAccessCombatTechPrep
+      - RMCAccessFieldDoctor
+      - CMAccessDropship
+      - CMAccessSquadLeaderPrep
+      - CMAccessQM
+      - CMAccessChemistry
+      - CMAccessCharlie
+      - CMAccessBravo
+      - CMAccessEngineering
+      - RMCAccessLogs
+      - RMCAccessSeniorCommand
+      - CMAccessMaint
+      - CMAccessDelta
+      - CMAccessFTLPrep
+      - CMAccessCMO
+      - CMAccessMedical
+      - CMAccessAlpha
+      - CMAccessMarineRifleman
+      - RMCAccessMorgue
+      - CMAccessArmory
+      - RMCAccessCommand
+      - CMAccessMedPrep
+      - CMAccessRequisitions
+      - CMAccessMarinePrep
+      - CMAccessResearch
+      - CMAccessCE
+      accessGroups:
+      - RMCBaseARESAccess
+      - RMCBaseMarineAccess
+      - RMCBaseMPAccess
+      - RMCBaseSquadAccess
+      - RMCBaseMedicalAccess
+      - RMCBaseCommandAccess
+      - RMCBaseEngineeringAccess
   - uid: 23604
     components:
     - type: Transform
       pos: -0.25,0.5
       parent: 1
+    - type: IdModificationConsole
+      jobList:
+      - MessTech
+      - CMP
+      - ASO
+      - Rifleman
+      - Researcher
+      - CMCE
+      - Synth
+      - SO
+      - WeaponSpec
+      - SmartGunOperator
+      - CMWarden
+      - HospitalCorpsman
+      - MP
+      - RMCFieldDoctor
+      - MaintTech
+      - CMCMO
+      - IntelOfficer
+      - OT
+      - CO
+      - Nurse
+      - CombatTech
+      - MarineMain
+      - FTL
+      - QuarterMaster
+      - Pilot
+      - DropshipCrewChief
+      - SquadLeader
+      - SEA
+      - RMCWeYaExec
+      - CMCargoTech
+      - CMMedbay
+      jobGroups:
+      - RMCBaseMiscellaneousJob
+      - RMCBaseMarinesJob
+      - RMCBaseRequisitionsJob
+      - RMCBaseMPJob
+      - RMCBaseEngineeringJob
+      - RMCBaseMedicalJob
+      - RMCBaseAuxiliaryJob
+      - RMCBaseCommandJob
+      accessList:
+      - CMAccessSpecPrep
+      - CMAccessKitchen
+      - RMCAccessDatabase
+      - CMAccessBrig
+      - CMAccessSmartPrep
+      - CMAccessOT
+      - CMAccessCMP
+      - CMAccessCombatTechPrep
+      - RMCAccessFieldDoctor
+      - CMAccessDropship
+      - CMAccessSquadLeaderPrep
+      - CMAccessQM
+      - CMAccessChemistry
+      - CMAccessCharlie
+      - CMAccessBravo
+      - CMAccessEngineering
+      - RMCAccessLogs
+      - RMCAccessSeniorCommand
+      - CMAccessMaint
+      - CMAccessDelta
+      - CMAccessFTLPrep
+      - CMAccessCMO
+      - CMAccessMedical
+      - CMAccessAlpha
+      - CMAccessMarineRifleman
+      - RMCAccessMorgue
+      - CMAccessArmory
+      - RMCAccessCommand
+      - CMAccessMedPrep
+      - CMAccessRequisitions
+      - CMAccessMarinePrep
+      - CMAccessResearch
+      - CMAccessCE
+      accessGroups:
+      - RMCBaseARESAccess
+      - RMCBaseMarineAccess
+      - RMCBaseMPAccess
+      - RMCBaseSquadAccess
+      - RMCBaseMedicalAccess
+      - RMCBaseCommandAccess
+      - RMCBaseEngineeringAccess
 - proto: RMCIndustryFreezer
   entities:
   - uid: 23605
@@ -172575,6 +173026,8 @@ entities:
       parent: 1
     - type: Ladder
       id: bridge2
+    - type: Fixtures
+      fixtures: {}
   - uid: 23637
     components:
     - type: Transform
@@ -172582,6 +173035,8 @@ entities:
       parent: 1
     - type: Ladder
       id: bridge1
+    - type: Fixtures
+      fixtures: {}
   - uid: 23638
     components:
     - type: Transform
@@ -172589,6 +173044,8 @@ entities:
       parent: 1
     - type: Ladder
       id: med2
+    - type: Fixtures
+      fixtures: {}
   - uid: 23639
     components:
     - type: Transform
@@ -172596,6 +173053,8 @@ entities:
       parent: 1
     - type: Ladder
       id: med1
+    - type: Fixtures
+      fixtures: {}
   - uid: 23640
     components:
     - type: Transform
@@ -172603,6 +173062,8 @@ entities:
       parent: 1
     - type: Ladder
       id: bridge3
+    - type: Fixtures
+      fixtures: {}
   - uid: 23641
     components:
     - type: Transform
@@ -172610,6 +173071,8 @@ entities:
       parent: 1
     - type: Ladder
       id: bridge4
+    - type: Fixtures
+      fixtures: {}
   - uid: 23642
     components:
     - type: Transform
@@ -172617,6 +173080,8 @@ entities:
       parent: 1
     - type: Ladder
       id: med3
+    - type: Fixtures
+      fixtures: {}
   - uid: 23643
     components:
     - type: Transform
@@ -172624,6 +173089,8 @@ entities:
       parent: 1
     - type: Ladder
       id: med4
+    - type: Fixtures
+      fixtures: {}
   - uid: 23644
     components:
     - type: Transform
@@ -172631,6 +173098,8 @@ entities:
       parent: 1
     - type: Ladder
       id: AftStarboardMaint
+    - type: Fixtures
+      fixtures: {}
   - uid: 23645
     components:
     - type: Transform
@@ -172638,6 +173107,8 @@ entities:
       parent: 1
     - type: Ladder
       id: kitchen
+    - type: Fixtures
+      fixtures: {}
   - uid: 23646
     components:
     - type: Transform
@@ -172645,6 +173116,8 @@ entities:
       parent: 1
     - type: Ladder
       id: cicladder4
+    - type: Fixtures
+      fixtures: {}
   - uid: 23647
     components:
     - type: Transform
@@ -172652,6 +173125,8 @@ entities:
       parent: 1
     - type: Ladder
       id: cicladder3
+    - type: Fixtures
+      fixtures: {}
   - uid: 23648
     components:
     - type: Transform
@@ -172659,6 +173134,8 @@ entities:
       parent: 1
     - type: Ladder
       id: engineeringladder
+    - type: Fixtures
+      fixtures: {}
   - uid: 23649
     components:
     - type: Transform
@@ -172666,6 +173143,8 @@ entities:
       parent: 1
     - type: Ladder
       id: AftPortMaint
+    - type: Fixtures
+      fixtures: {}
   - uid: 23650
     components:
     - type: Transform
@@ -172673,6 +173152,8 @@ entities:
       parent: 1
     - type: Ladder
       id: ForeStarboardMaint
+    - type: Fixtures
+      fixtures: {}
   - uid: 23651
     components:
     - type: Transform
@@ -172680,6 +173161,8 @@ entities:
       parent: 1
     - type: Ladder
       id: ForeStarboardMaint
+    - type: Fixtures
+      fixtures: {}
   - uid: 23652
     components:
     - type: Transform
@@ -172687,6 +173170,8 @@ entities:
       parent: 1
     - type: Ladder
       id: ForePortMaint
+    - type: Fixtures
+      fixtures: {}
   - uid: 23653
     components:
     - type: Transform
@@ -172694,6 +173179,8 @@ entities:
       parent: 1
     - type: Ladder
       id: med3
+    - type: Fixtures
+      fixtures: {}
   - uid: 23654
     components:
     - type: Transform
@@ -172701,6 +173188,8 @@ entities:
       parent: 1
     - type: Ladder
       id: med2
+    - type: Fixtures
+      fixtures: {}
   - uid: 23655
     components:
     - type: Transform
@@ -172708,6 +173197,8 @@ entities:
       parent: 1
     - type: Ladder
       id: med1
+    - type: Fixtures
+      fixtures: {}
   - uid: 23656
     components:
     - type: Transform
@@ -172715,6 +173206,8 @@ entities:
       parent: 1
     - type: Ladder
       id: bridge4
+    - type: Fixtures
+      fixtures: {}
   - uid: 23657
     components:
     - type: Transform
@@ -172722,6 +173215,8 @@ entities:
       parent: 1
     - type: Ladder
       id: engineeringladder
+    - type: Fixtures
+      fixtures: {}
   - uid: 23658
     components:
     - type: Transform
@@ -172729,6 +173224,8 @@ entities:
       parent: 1
     - type: Ladder
       id: AftStarboardMaint
+    - type: Fixtures
+      fixtures: {}
   - uid: 23659
     components:
     - type: Transform
@@ -172736,6 +173233,8 @@ entities:
       parent: 1
     - type: Ladder
       id: kitchen
+    - type: Fixtures
+      fixtures: {}
   - uid: 23660
     components:
     - type: Transform
@@ -172743,6 +173242,8 @@ entities:
       parent: 1
     - type: Ladder
       id: cicladder4
+    - type: Fixtures
+      fixtures: {}
   - uid: 23661
     components:
     - type: Transform
@@ -172750,6 +173251,8 @@ entities:
       parent: 1
     - type: Ladder
       id: ForePortMaint
+    - type: Fixtures
+      fixtures: {}
   - uid: 23662
     components:
     - type: Transform
@@ -172757,6 +173260,8 @@ entities:
       parent: 1
     - type: Ladder
       id: bridge1
+    - type: Fixtures
+      fixtures: {}
   - uid: 23663
     components:
     - type: Transform
@@ -172764,6 +173269,8 @@ entities:
       parent: 1
     - type: Ladder
       id: bridge2
+    - type: Fixtures
+      fixtures: {}
   - uid: 23664
     components:
     - type: Transform
@@ -172771,6 +173278,8 @@ entities:
       parent: 1
     - type: Ladder
       id: bridge3
+    - type: Fixtures
+      fixtures: {}
   - uid: 23665
     components:
     - type: Transform
@@ -172778,6 +173287,8 @@ entities:
       parent: 1
     - type: Ladder
       id: cicladder2
+    - type: Fixtures
+      fixtures: {}
   - uid: 23666
     components:
     - type: Transform
@@ -172785,6 +173296,8 @@ entities:
       parent: 1
     - type: Ladder
       id: cicladder3
+    - type: Fixtures
+      fixtures: {}
   - uid: 23667
     components:
     - type: Transform
@@ -172792,6 +173305,8 @@ entities:
       parent: 1
     - type: Ladder
       id: med4
+    - type: Fixtures
+      fixtures: {}
   - uid: 23668
     components:
     - type: Transform
@@ -172799,6 +173314,8 @@ entities:
       parent: 1
     - type: Ladder
       id: cicladder1
+    - type: Fixtures
+      fixtures: {}
   - uid: 23669
     components:
     - type: Transform
@@ -172806,6 +173323,8 @@ entities:
       parent: 1
     - type: Ladder
       id: cicladder1
+    - type: Fixtures
+      fixtures: {}
   - uid: 23670
     components:
     - type: Transform
@@ -172813,6 +173332,8 @@ entities:
       parent: 1
     - type: Ladder
       id: cicladder2
+    - type: Fixtures
+      fixtures: {}
   - uid: 23671
     components:
     - type: Transform
@@ -172820,6 +173341,8 @@ entities:
       parent: 1
     - type: Ladder
       id: AftPortMaint
+    - type: Fixtures
+      fixtures: {}
 - proto: RMCLamp
   entities:
   - uid: 2
@@ -173099,440 +173622,374 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -96.5,-15.5
       parent: 1
-    - type: PointLight
   - uid: 23724
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -99.5,-15.5
       parent: 1
-    - type: PointLight
   - uid: 23725
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,24.5
       parent: 1
-    - type: PointLight
   - uid: 23726
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,24.5
       parent: 1
-    - type: PointLight
   - uid: 23727
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 63.5,4.5
       parent: 1
-    - type: PointLight
   - uid: 23728
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -41.5,-11.5
       parent: 1
-    - type: PointLight
   - uid: 23729
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -36.5,-11.5
       parent: 1
-    - type: PointLight
   - uid: 23730
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,8.5
       parent: 1
-    - type: PointLight
   - uid: 23731
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,-9.5
       parent: 1
-    - type: PointLight
   - uid: 23732
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,110.5
       parent: 1
-    - type: PointLight
   - uid: 23733
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,-11.5
       parent: 1
-    - type: PointLight
   - uid: 23734
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,97.5
       parent: 1
-    - type: PointLight
   - uid: 23735
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-9.5
       parent: 1
-    - type: PointLight
   - uid: 23736
     components:
     - type: Transform
       pos: -23.5,107.5
       parent: 1
-    - type: PointLight
   - uid: 23737
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,-32.5
       parent: 1
-    - type: PointLight
   - uid: 23738
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,-16.5
       parent: 1
-    - type: PointLight
   - uid: 23739
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,-16.5
       parent: 1
-    - type: PointLight
   - uid: 23740
     components:
     - type: Transform
       pos: 47.5,17.5
       parent: 1
-    - type: PointLight
   - uid: 23741
     components:
     - type: Transform
       pos: 25.5,-8.5
       parent: 1
-    - type: PointLight
   - uid: 23742
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -63.5,0.5
       parent: 1
-    - type: PointLight
   - uid: 23743
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -66.5,4.5
       parent: 1
-    - type: PointLight
   - uid: 23744
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -60.5,4.5
       parent: 1
-    - type: PointLight
   - uid: 23745
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -67.5,5.5
       parent: 1
-    - type: PointLight
   - uid: 23746
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -67.5,9.5
       parent: 1
-    - type: PointLight
   - uid: 23747
     components:
     - type: Transform
       pos: -66.5,10.5
       parent: 1
-    - type: PointLight
   - uid: 23748
     components:
     - type: Transform
       pos: -60.5,10.5
       parent: 1
-    - type: PointLight
   - uid: 23749
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.5,9.5
       parent: 1
-    - type: PointLight
   - uid: 23750
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.5,5.5
       parent: 1
-    - type: PointLight
   - uid: 23751
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -64.5,8.5
       parent: 1
-    - type: PointLight
   - uid: 23752
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -62.5,8.5
       parent: 1
-    - type: PointLight
   - uid: 23753
     components:
     - type: Transform
       pos: -62.5,6.5
       parent: 1
-    - type: PointLight
   - uid: 23754
     components:
     - type: Transform
       pos: -64.5,6.5
       parent: 1
-    - type: PointLight
   - uid: 23755
     components:
     - type: Transform
       pos: -60.5,-13.5
       parent: 1
-    - type: PointLight
   - uid: 23756
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -60.5,-15.5
       parent: 1
-    - type: PointLight
   - uid: 23757
     components:
     - type: Transform
       pos: -66.5,-13.5
       parent: 1
-    - type: PointLight
   - uid: 23758
     components:
     - type: Transform
       pos: -75.5,-13.5
       parent: 1
-    - type: PointLight
   - uid: 23759
     components:
     - type: Transform
       pos: -71.5,-13.5
       parent: 1
-    - type: PointLight
   - uid: 23760
     components:
     - type: Transform
       pos: -80.5,-13.5
       parent: 1
-    - type: PointLight
   - uid: 23761
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -79.5,-15.5
       parent: 1
-    - type: PointLight
   - uid: 23762
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -67.5,-15.5
       parent: 1
-    - type: PointLight
   - uid: 23763
     components:
     - type: Transform
       pos: -79.5,-20.5
       parent: 1
-    - type: PointLight
   - uid: 23764
     components:
     - type: Transform
       pos: -75.5,-20.5
       parent: 1
-    - type: PointLight
   - uid: 23765
     components:
     - type: Transform
       pos: -71.5,-20.5
       parent: 1
-    - type: PointLight
   - uid: 23766
     components:
     - type: Transform
       pos: -67.5,-20.5
       parent: 1
-    - type: PointLight
   - uid: 23767
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -84.5,-17.5
       parent: 1
-    - type: PointLight
   - uid: 23768
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -89.5,-17.5
       parent: 1
-    - type: PointLight
   - uid: 23769
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -81.5,-8.5
       parent: 1
-    - type: PointLight
   - uid: 23770
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -82.5,-9.5
       parent: 1
-    - type: PointLight
   - uid: 23771
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -83.5,-8.5
       parent: 1
-    - type: PointLight
   - uid: 23772
     components:
     - type: Transform
       pos: -82.5,-7.5
       parent: 1
-    - type: PointLight
   - uid: 23773
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -89.5,-8.5
       parent: 1
-    - type: PointLight
   - uid: 23774
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -91.5,-8.5
       parent: 1
-    - type: PointLight
   - uid: 23775
     components:
     - type: Transform
       pos: -96.5,-12.5
       parent: 1
-    - type: PointLight
   - uid: 23776
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -102.5,-8.5
       parent: 1
-    - type: PointLight
   - uid: 23777
     components:
     - type: Transform
       pos: -105.5,-5.5
       parent: 1
-    - type: PointLight
   - uid: 23778
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -105.5,-7.5
       parent: 1
-    - type: PointLight
   - uid: 23779
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -109.5,-7.5
       parent: 1
-    - type: PointLight
   - uid: 23780
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -109.5,-4.5
       parent: 1
-    - type: PointLight
   - uid: 23781
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -115.5,-4.5
       parent: 1
-    - type: PointLight
   - uid: 23782
     components:
     - type: Transform
       pos: -115.5,3.5
       parent: 1
-    - type: PointLight
   - uid: 23783
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -109.5,3.5
       parent: 1
-    - type: PointLight
   - uid: 23784
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -113.5,9.5
       parent: 1
-    - type: PointLight
   - uid: 23785
     components:
     - type: Transform
       pos: -109.5,6.5
       parent: 1
-    - type: PointLight
   - uid: 23786
     components:
     - type: Transform
       pos: -105.5,6.5
       parent: 1
-    - type: PointLight
   - uid: 23787
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -105.5,4.5
       parent: 1
-    - type: PointLight
   - uid: 23788
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -99.5,-0.5
       parent: 1
-    - type: PointLight
     - type: Timer
   - uid: 23789
     components:
@@ -173540,7 +173997,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -101.5,-0.5
       parent: 1
-    - type: PointLight
     - type: Timer
   - uid: 23790
     components:
@@ -173548,5912 +174004,5030 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -104.5,-0.5
       parent: 1
-    - type: PointLight
   - uid: 23791
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -109.5,-0.5
       parent: 1
-    - type: PointLight
   - uid: 23792
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -102.5,-0.5
       parent: 1
-    - type: PointLight
     - type: Timer
   - uid: 23793
     components:
     - type: Transform
       pos: -91.5,-3.5
       parent: 1
-    - type: PointLight
   - uid: 23794
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -89.5,17.5
       parent: 1
-    - type: PointLight
   - uid: 23795
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -84.5,17.5
       parent: 1
-    - type: PointLight
   - uid: 23796
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -89.5,9.5
       parent: 1
-    - type: PointLight
   - uid: 23797
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -114.5,-0.5
       parent: 1
-    - type: PointLight
   - uid: 23798
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -57.5,12.5
       parent: 1
-    - type: PointLight
   - uid: 23799
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,6.5
       parent: 1
-    - type: PointLight
   - uid: 23800
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
-    - type: PointLight
   - uid: 23801
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-3.5
       parent: 1
-    - type: PointLight
   - uid: 23802
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 1
-    - type: PointLight
   - uid: 23803
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-2.5
       parent: 1
-    - type: PointLight
   - uid: 23804
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,1.5
       parent: 1
-    - type: PointLight
   - uid: 23805
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-6.5
       parent: 1
-    - type: PointLight
   - uid: 23806
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-11.5
       parent: 1
-    - type: PointLight
   - uid: 23807
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-7.5
       parent: 1
-    - type: PointLight
   - uid: 23808
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-7.5
       parent: 1
-    - type: PointLight
   - uid: 23809
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-    - type: PointLight
   - uid: 23810
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
-    - type: PointLight
   - uid: 23811
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,12.5
       parent: 1
-    - type: PointLight
   - uid: 23812
     components:
     - type: Transform
       pos: -10.5,14.5
       parent: 1
-    - type: PointLight
   - uid: 23813
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,12.5
       parent: 1
-    - type: PointLight
   - uid: 23814
     components:
     - type: Transform
       pos: -6.5,14.5
       parent: 1
-    - type: PointLight
   - uid: 23815
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,14.5
       parent: 1
-    - type: PointLight
   - uid: 23816
     components:
     - type: Transform
       pos: -38.5,14.5
       parent: 1
-    - type: PointLight
   - uid: 23817
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -37.5,17.5
       parent: 1
-    - type: PointLight
   - uid: 23818
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,21.5
       parent: 1
-    - type: PointLight
   - uid: 23819
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -37.5,22.5
       parent: 1
-    - type: PointLight
   - uid: 23820
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -36.5,25.5
       parent: 1
-    - type: PointLight
   - uid: 23821
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,25.5
       parent: 1
-    - type: PointLight
   - uid: 23822
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,22.5
       parent: 1
-    - type: PointLight
   - uid: 23823
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,17.5
       parent: 1
-    - type: PointLight
   - uid: 23824
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,17.5
       parent: 1
-    - type: PointLight
   - uid: 23825
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,15.5
       parent: 1
-    - type: PointLight
   - uid: 23826
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,19.5
       parent: 1
-    - type: PointLight
   - uid: 23827
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,19.5
       parent: 1
-    - type: PointLight
   - uid: 23828
     components:
     - type: Transform
       pos: -10.5,21.5
       parent: 1
-    - type: PointLight
   - uid: 23829
     components:
     - type: Transform
       pos: -8.5,22.5
       parent: 1
-    - type: PointLight
   - uid: 23830
     components:
     - type: Transform
       pos: -6.5,21.5
       parent: 1
-    - type: PointLight
   - uid: 23831
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,19.5
       parent: 1
-    - type: PointLight
   - uid: 23832
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -46.5,12.5
       parent: 1
-    - type: PointLight
   - uid: 23833
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -49.5,12.5
       parent: 1
-    - type: PointLight
   - uid: 23834
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -50.5,-15.5
       parent: 1
-    - type: PointLight
   - uid: 23835
     components:
     - type: Transform
       pos: -50.5,-13.5
       parent: 1
-    - type: PointLight
   - uid: 23836
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,-18.5
       parent: 1
-    - type: PointLight
   - uid: 23837
     components:
     - type: Transform
       pos: -23.5,-21.5
       parent: 1
-    - type: PointLight
   - uid: 23838
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,-15.5
       parent: 1
-    - type: PointLight
   - uid: 23839
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,-16.5
       parent: 1
-    - type: PointLight
   - uid: 23840
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,-21.5
       parent: 1
-    - type: PointLight
   - uid: 23841
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-19.5
       parent: 1
-    - type: PointLight
   - uid: 23842
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-16.5
       parent: 1
-    - type: PointLight
   - uid: 23843
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-25.5
       parent: 1
-    - type: PointLight
   - uid: 23844
     components:
     - type: Transform
       pos: -8.5,-13.5
       parent: 1
-    - type: PointLight
   - uid: 23845
     components:
     - type: Transform
       pos: -1.5,-13.5
       parent: 1
-    - type: PointLight
   - uid: 23846
     components:
     - type: Transform
       pos: 2.5,-13.5
       parent: 1
-    - type: PointLight
   - uid: 23847
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-17.5
       parent: 1
-    - type: PointLight
   - uid: 23848
     components:
     - type: Transform
       pos: 0.5,-20.5
       parent: 1
-    - type: PointLight
   - uid: 23849
     components:
     - type: Transform
       pos: -4.5,-20.5
       parent: 1
-    - type: PointLight
   - uid: 23850
     components:
     - type: Transform
       pos: -9.5,-26.5
       parent: 1
-    - type: PointLight
   - uid: 23851
     components:
     - type: Transform
       pos: -3.5,-26.5
       parent: 1
-    - type: PointLight
   - uid: 23852
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-22.5
       parent: 1
-    - type: PointLight
   - uid: 23853
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-23.5
       parent: 1
-    - type: PointLight
   - uid: 23854
     components:
     - type: Transform
       pos: 6.5,-26.5
       parent: 1
-    - type: PointLight
   - uid: 23855
     components:
     - type: Transform
       pos: 11.5,-26.5
       parent: 1
-    - type: PointLight
   - uid: 23856
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-24.5
       parent: 1
-    - type: PointLight
   - uid: 23857
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,-16.5
       parent: 1
-    - type: PointLight
   - uid: 23858
     components:
     - type: Transform
       pos: 33.5,-29.5
       parent: 1
-    - type: PointLight
   - uid: 23859
     components:
     - type: Transform
       pos: 48.5,-29.5
       parent: 1
-    - type: PointLight
   - uid: 23860
     components:
     - type: Transform
       pos: 50.5,-29.5
       parent: 1
-    - type: PointLight
   - uid: 23861
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 48.5,-15.5
       parent: 1
-    - type: PointLight
   - uid: 23862
     components:
     - type: Transform
       pos: 31.5,-28.5
       parent: 1
-    - type: PointLight
   - uid: 23863
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 50.5,-15.5
       parent: 1
-    - type: PointLight
   - uid: 23864
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,-15.5
       parent: 1
-    - type: PointLight
   - uid: 23865
     components:
     - type: Transform
       pos: 15.5,-32.5
       parent: 1
-    - type: PointLight
   - uid: 23866
     components:
     - type: Transform
       pos: 20.5,-32.5
       parent: 1
-    - type: PointLight
   - uid: 23867
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 28.5,-36.5
       parent: 1
-    - type: PointLight
   - uid: 23868
     components:
     - type: Transform
       pos: 25.5,-32.5
       parent: 1
-    - type: PointLight
   - uid: 23869
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,-36.5
       parent: 1
-    - type: PointLight
   - uid: 23870
     components:
     - type: Transform
       pos: 31.5,-42.5
       parent: 1
-    - type: PointLight
   - uid: 23871
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,-36.5
       parent: 1
-    - type: PointLight
   - uid: 23872
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-27.5
       parent: 1
-    - type: PointLight
   - uid: 23873
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-24.5
       parent: 1
-    - type: PointLight
   - uid: 23874
     components:
     - type: Transform
       pos: 20.5,-28.5
       parent: 1
-    - type: PointLight
   - uid: 23875
     components:
     - type: Transform
       pos: 23.5,-28.5
       parent: 1
-    - type: PointLight
   - uid: 23876
     components:
     - type: Transform
       pos: 27.5,-28.5
       parent: 1
-    - type: PointLight
   - uid: 23877
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,-16.5
       parent: 1
-    - type: PointLight
   - uid: 23878
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,-16.5
       parent: 1
-    - type: PointLight
   - uid: 23879
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,-16.5
       parent: 1
-    - type: PointLight
   - uid: 23880
     components:
     - type: Transform
       pos: 22.5,-14.5
       parent: 1
-    - type: PointLight
   - uid: 23881
     components:
     - type: Transform
       pos: 29.5,-14.5
       parent: 1
-    - type: PointLight
   - uid: 23882
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,-23.5
       parent: 1
-    - type: PointLight
   - uid: 23883
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,-21.5
       parent: 1
-    - type: PointLight
   - uid: 23884
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,-22.5
       parent: 1
-    - type: PointLight
   - uid: 23885
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-20.5
       parent: 1
-    - type: PointLight
   - uid: 23886
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-17.5
       parent: 1
-    - type: PointLight
   - uid: 23887
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-17.5
       parent: 1
-    - type: PointLight
   - uid: 23888
     components:
     - type: Transform
       pos: 11.5,-21.5
       parent: 1
-    - type: PointLight
   - uid: 23889
     components:
     - type: Transform
       pos: 5.5,-21.5
       parent: 1
-    - type: PointLight
   - uid: 23890
     components:
     - type: Transform
       pos: 14.5,-13.5
       parent: 1
-    - type: PointLight
   - uid: 23891
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-11.5
       parent: 1
-    - type: PointLight
   - uid: 23892
     components:
     - type: Transform
       pos: 11.5,-8.5
       parent: 1
-    - type: PointLight
   - uid: 23893
     components:
     - type: Transform
       pos: 17.5,-8.5
       parent: 1
-    - type: PointLight
   - uid: 23894
     components:
     - type: Transform
       pos: 22.5,-8.5
       parent: 1
-    - type: PointLight
   - uid: 23895
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,-4.5
       parent: 1
-    - type: PointLight
   - uid: 23896
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,-0.5
       parent: 1
-    - type: PointLight
   - uid: 23897
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,3.5
       parent: 1
-    - type: PointLight
   - uid: 23898
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,7.5
       parent: 1
-    - type: PointLight
   - uid: 23899
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,7.5
       parent: 1
-    - type: PointLight
   - uid: 23900
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,7.5
       parent: 1
-    - type: PointLight
   - uid: 23901
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,7.5
       parent: 1
-    - type: PointLight
   - uid: 23902
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,5.5
       parent: 1
-    - type: PointLight
   - uid: 23903
     components:
     - type: Transform
       pos: 11.5,10.5
       parent: 1
-    - type: PointLight
   - uid: 23904
     components:
     - type: Transform
       pos: 17.5,9.5
       parent: 1
-    - type: PointLight
   - uid: 23905
     components:
     - type: Transform
       pos: 22.5,9.5
       parent: 1
-    - type: PointLight
   - uid: 23906
     components:
     - type: Transform
       pos: 25.5,9.5
       parent: 1
-    - type: PointLight
   - uid: 23907
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 28.5,-0.5
       parent: 1
-    - type: PointLight
   - uid: 23908
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-0.5
       parent: 1
-    - type: PointLight
   - uid: 23909
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 35.5,-0.5
       parent: 1
-    - type: PointLight
   - uid: 23910
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,3.5
       parent: 1
-    - type: PointLight
   - uid: 23911
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-4.5
       parent: 1
-    - type: PointLight
   - uid: 23912
     components:
     - type: Transform
       pos: 37.5,-3.5
       parent: 1
-    - type: PointLight
   - uid: 23913
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,2.5
       parent: 1
-    - type: PointLight
   - uid: 23914
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 41.5,7.5
       parent: 1
-    - type: PointLight
   - uid: 23915
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 45.5,7.5
       parent: 1
-    - type: PointLight
   - uid: 23916
     components:
     - type: Transform
       pos: 45.5,9.5
       parent: 1
-    - type: PointLight
   - uid: 23917
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 47.5,1.5
       parent: 1
-    - type: PointLight
   - uid: 23918
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 47.5,-1.5
       parent: 1
-    - type: PointLight
   - uid: 23919
     components:
     - type: Transform
       pos: 45.5,-5.5
       parent: 1
-    - type: PointLight
   - uid: 23920
     components:
     - type: Transform
       pos: 41.5,-7.5
       parent: 1
-    - type: PointLight
   - uid: 23921
     components:
     - type: Transform
       pos: 52.5,-2.5
       parent: 1
-    - type: PointLight
   - uid: 23922
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 53.5,5.5
       parent: 1
-    - type: PointLight
   - uid: 23923
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 65.5,4.5
       parent: 1
-    - type: PointLight
   - uid: 23924
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 65.5,-5.5
       parent: 1
-    - type: PointLight
   - uid: 23925
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 75.5,2.5
       parent: 1
-    - type: PointLight
   - uid: 23926
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 76.5,5.5
       parent: 1
-    - type: PointLight
   - uid: 23927
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 74.5,15.5
       parent: 1
-    - type: PointLight
   - uid: 23928
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 73.5,17.5
       parent: 1
-    - type: PointLight
   - uid: 23929
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 68.5,17.5
       parent: 1
-    - type: PointLight
   - uid: 23930
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 70.5,17.5
       parent: 1
-    - type: PointLight
   - uid: 23931
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 64.5,17.5
       parent: 1
-    - type: PointLight
   - uid: 23932
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 62.5,17.5
       parent: 1
-    - type: PointLight
   - uid: 23933
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 62.5,20.5
       parent: 1
-    - type: PointLight
   - uid: 23934
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 58.5,20.5
       parent: 1
-    - type: PointLight
   - uid: 23935
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 53.5,20.5
       parent: 1
-    - type: PointLight
   - uid: 23936
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 53.5,16.5
       parent: 1
-    - type: PointLight
   - uid: 23937
     components:
     - type: Transform
       pos: 50.5,14.5
       parent: 1
-    - type: PointLight
   - uid: 23938
     components:
     - type: Transform
       pos: 48.5,14.5
       parent: 1
-    - type: PointLight
   - uid: 23939
     components:
     - type: Transform
       pos: 33.5,14.5
       parent: 1
-    - type: PointLight
   - uid: 23940
     components:
     - type: Transform
       pos: 31.5,15.5
       parent: 1
-    - type: PointLight
   - uid: 23941
     components:
     - type: Transform
       pos: 35.5,18.5
       parent: 1
-    - type: PointLight
   - uid: 23942
     components:
     - type: Transform
       pos: 30.5,18.5
       parent: 1
-    - type: PointLight
   - uid: 23943
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,27.5
       parent: 1
-    - type: PointLight
   - uid: 23944
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 53.5,27.5
       parent: 1
-    - type: PointLight
   - uid: 23945
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 50.5,28.5
       parent: 1
-    - type: PointLight
   - uid: 23946
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 48.5,28.5
       parent: 1
-    - type: PointLight
   - uid: 23947
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,28.5
       parent: 1
-    - type: PointLight
   - uid: 23948
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,27.5
       parent: 1
-    - type: PointLight
   - uid: 23949
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,24.5
       parent: 1
-    - type: PointLight
   - uid: 23950
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,24.5
       parent: 1
-    - type: PointLight
   - uid: 23951
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 47.5,25.5
       parent: 1
-    - type: PointLight
   - uid: 23952
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,21.5
       parent: 1
-    - type: PointLight
   - uid: 23953
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,22.5
       parent: 1
-    - type: PointLight
   - uid: 23954
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,20.5
       parent: 1
-    - type: PointLight
   - uid: 23955
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,19.5
       parent: 1
-    - type: PointLight
   - uid: 23956
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,23.5
       parent: 1
-    - type: PointLight
   - uid: 23957
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,26.5
       parent: 1
-    - type: PointLight
   - uid: 23958
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,16.5
       parent: 1
-    - type: PointLight
   - uid: 23959
     components:
     - type: Transform
       pos: 20.5,15.5
       parent: 1
-    - type: PointLight
   - uid: 23960
     components:
     - type: Transform
       pos: 23.5,15.5
       parent: 1
-    - type: PointLight
   - uid: 23961
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,27.5
       parent: 1
-    - type: PointLight
   - uid: 23962
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,27.5
       parent: 1
-    - type: PointLight
   - uid: 23963
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,13.5
       parent: 1
-    - type: PointLight
   - uid: 23964
     components:
     - type: Transform
       pos: 27.5,15.5
       parent: 1
-    - type: PointLight
   - uid: 23965
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,13.5
       parent: 1
-    - type: PointLight
   - uid: 23966
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,27.5
       parent: 1
-    - type: PointLight
   - uid: 23967
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,31.5
       parent: 1
-    - type: PointLight
   - uid: 23968
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,31.5
       parent: 1
-    - type: PointLight
   - uid: 23969
     components:
     - type: Transform
       pos: 24.5,29.5
       parent: 1
-    - type: PointLight
   - uid: 23970
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,31.5
       parent: 1
-    - type: PointLight
   - uid: 23971
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 28.5,35.5
       parent: 1
-    - type: PointLight
   - uid: 23972
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,35.5
       parent: 1
-    - type: PointLight
   - uid: 23973
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,41.5
       parent: 1
-    - type: PointLight
   - uid: 23974
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,30.5
       parent: 1
-    - type: PointLight
   - uid: 23975
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,28.5
       parent: 1
-    - type: PointLight
   - uid: 23976
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,33.5
       parent: 1
-    - type: PointLight
   - uid: 23977
     components:
     - type: Transform
       pos: 11.5,27.5
       parent: 1
-    - type: PointLight
   - uid: 23978
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,16.5
       parent: 1
-    - type: PointLight
   - uid: 23979
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,16.5
       parent: 1
-    - type: PointLight
   - uid: 23980
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,20.5
       parent: 1
-    - type: PointLight
   - uid: 23981
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,20.5
       parent: 1
-    - type: PointLight
   - uid: 23982
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,16.5
       parent: 1
-    - type: PointLight
   - uid: 23983
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,8.5
       parent: 1
-    - type: PointLight
   - uid: 23984
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-9.5
       parent: 1
-    - type: PointLight
   - uid: 23985
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,-10.5
       parent: 1
-    - type: PointLight
   - uid: 23986
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,-10.5
       parent: 1
-    - type: PointLight
   - uid: 23987
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,-10.5
       parent: 1
-    - type: PointLight
   - uid: 23988
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,-10.5
       parent: 1
-    - type: PointLight
   - uid: 23989
     components:
     - type: Transform
       pos: 35.5,-8.5
       parent: 1
-    - type: PointLight
   - uid: 23990
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 33.5,-6.5
       parent: 1
-    - type: PointLight
   - uid: 23991
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 31.5,-6.5
       parent: 1
-    - type: PointLight
   - uid: 23992
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 31.5,5.5
       parent: 1
-    - type: PointLight
   - uid: 23993
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 51.5,1.5
       parent: 1
-    - type: PointLight
   - uid: 23994
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,20.5
       parent: 1
-    - type: PointLight
   - uid: 23995
     components:
     - type: Transform
       pos: -23.5,14.5
       parent: 1
-    - type: PointLight
   - uid: 23996
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 57.5,30.5
       parent: 1
-    - type: PointLight
   - uid: 23997
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,30.5
       parent: 1
-    - type: PointLight
   - uid: 23998
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 60.5,30.5
       parent: 1
-    - type: PointLight
   - uid: 23999
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 65.5,30.5
       parent: 1
-    - type: PointLight
   - uid: 24000
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,25.5
       parent: 1
-    - type: PointLight
   - uid: 24001
     components:
     - type: Transform
       pos: 63.5,23.5
       parent: 1
-    - type: PointLight
   - uid: 24002
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 83.5,15.5
       parent: 1
-    - type: PointLight
   - uid: 24003
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 87.5,15.5
       parent: 1
-    - type: PointLight
   - uid: 24004
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,12.5
       parent: 1
-    - type: PointLight
   - uid: 24005
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 49.5,12.5
       parent: 1
-    - type: PointLight
   - uid: 24006
     components:
     - type: Transform
       pos: 56.5,10.5
       parent: 1
-    - type: PointLight
   - uid: 24007
     components:
     - type: Transform
       pos: 64.5,10.5
       parent: 1
-    - type: PointLight
   - uid: 24008
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 53.5,-16.5
       parent: 1
-    - type: PointLight
   - uid: 24009
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 75.5,-3.5
       parent: 1
-    - type: PointLight
   - uid: 24010
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 78.5,-3.5
       parent: 1
-    - type: PointLight
   - uid: 24011
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 78.5,2.5
       parent: 1
-    - type: PointLight
   - uid: 24012
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 85.5,4.5
       parent: 1
-    - type: PointLight
   - uid: 24013
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 85.5,-5.5
       parent: 1
-    - type: PointLight
   - uid: 24014
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 90.5,2.5
       parent: 1
-    - type: PointLight
   - uid: 24015
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 90.5,-3.5
       parent: 1
-    - type: PointLight
   - uid: 24016
     components:
     - type: Transform
       pos: 81.5,-8.5
       parent: 1
-    - type: PointLight
   - uid: 24017
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 90.5,-7.5
       parent: 1
-    - type: PointLight
   - uid: 24018
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 90.5,-3.5
       parent: 1
-    - type: PointLight
   - uid: 24019
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 90.5,2.5
       parent: 1
-    - type: PointLight
   - uid: 24020
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 99.5,1.5
       parent: 1
-    - type: PointLight
   - uid: 24021
     components:
     - type: Transform
       pos: 99.5,-2.5
       parent: 1
-    - type: PointLight
   - uid: 24022
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 97.5,-5.5
       parent: 1
-    - type: PointLight
   - uid: 24023
     components:
     - type: Transform
       pos: 97.5,4.5
       parent: 1
-    - type: PointLight
   - uid: 24024
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 90.5,6.5
       parent: 1
-    - type: PointLight
   - uid: 24025
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 81.5,7.5
       parent: 1
-    - type: PointLight
   - uid: 24026
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 105.5,-0.5
       parent: 1
-    - type: PointLight
   - uid: 24027
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 107.5,-0.5
       parent: 1
-    - type: PointLight
   - uid: 24028
     components:
     - type: Transform
       pos: 103.5,-6.5
       parent: 1
-    - type: PointLight
   - uid: 24029
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 103.5,5.5
       parent: 1
-    - type: PointLight
   - uid: 24030
     components:
     - type: Transform
       pos: 81.5,11.5
       parent: 1
-    - type: PointLight
   - uid: 24031
     components:
     - type: Transform
       pos: 88.5,11.5
       parent: 1
-    - type: PointLight
   - uid: 24032
     components:
     - type: Transform
       pos: 81.5,-16.5
       parent: 1
-    - type: PointLight
   - uid: 24033
     components:
     - type: Transform
       pos: 84.5,-16.5
       parent: 1
-    - type: PointLight
   - uid: 24034
     components:
     - type: Transform
       pos: 87.5,-16.5
       parent: 1
-    - type: PointLight
   - uid: 24035
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 87.5,-12.5
       parent: 1
-    - type: PointLight
   - uid: 24036
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,-19.5
       parent: 1
-    - type: PointLight
   - uid: 24037
     components:
     - type: Transform
       pos: 30.5,-25.5
       parent: 1
-    - type: PointLight
   - uid: 24038
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,-19.5
       parent: 1
-    - type: PointLight
   - uid: 24039
     components:
     - type: Transform
       pos: 35.5,-25.5
       parent: 1
-    - type: PointLight
   - uid: 24040
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,-26.5
       parent: 1
-    - type: PointLight
   - uid: 24041
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,-18.5
       parent: 1
-    - type: PointLight
   - uid: 24042
     components:
     - type: Transform
       pos: 35.5,-13.5
       parent: 1
-    - type: PointLight
   - uid: 24043
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 45.5,-10.5
       parent: 1
-    - type: PointLight
   - uid: 24044
     components:
     - type: Transform
       pos: 56.5,-13.5
       parent: 1
-    - type: PointLight
   - uid: 24045
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 64.5,-11.5
       parent: 1
-    - type: PointLight
   - uid: 24046
     components:
     - type: Transform
       pos: 74.5,-13.5
       parent: 1
-    - type: PointLight
   - uid: 24047
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 74.5,12.5
       parent: 1
-    - type: PointLight
   - uid: 24048
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 76.5,-6.5
       parent: 1
-    - type: PointLight
   - uid: 24049
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 53.5,-21.5
       parent: 1
-    - type: PointLight
   - uid: 24050
     components:
     - type: Transform
       pos: 57.5,-20.5
       parent: 1
-    - type: PointLight
   - uid: 24051
     components:
     - type: Transform
       pos: 63.5,-17.5
       parent: 1
-    - type: PointLight
   - uid: 24052
     components:
     - type: Transform
       pos: 69.5,-17.5
       parent: 1
-    - type: PointLight
   - uid: 24053
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 64.5,-20.5
       parent: 1
-    - type: PointLight
   - uid: 24054
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 73.5,-19.5
       parent: 1
-    - type: PointLight
   - uid: 24055
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 74.5,-16.5
       parent: 1
-    - type: PointLight
   - uid: 24056
     components:
     - type: Transform
       pos: 66.5,-28.5
       parent: 1
-    - type: PointLight
   - uid: 24057
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 64.5,-24.5
       parent: 1
-    - type: PointLight
   - uid: 24058
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 65.5,-31.5
       parent: 1
-    - type: PointLight
   - uid: 24059
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-29.5
       parent: 1
-    - type: PointLight
   - uid: 24060
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 60.5,-29.5
       parent: 1
-    - type: PointLight
   - uid: 24061
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 57.5,-31.5
       parent: 1
-    - type: PointLight
   - uid: 24062
     components:
     - type: Transform
       pos: 56.5,-28.5
       parent: 1
-    - type: PointLight
   - uid: 24063
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 53.5,-23.5
       parent: 1
-    - type: PointLight
   - uid: 24064
     components:
     - type: Transform
       pos: -128.5,100.5
       parent: 1
-    - type: PointLight
   - uid: 24065
     components:
     - type: Transform
       pos: -122.5,99.5
       parent: 1
-    - type: PointLight
   - uid: 24066
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -118.5,103.5
       parent: 1
-    - type: PointLight
   - uid: 24067
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -120.5,103.5
       parent: 1
-    - type: PointLight
   - uid: 24068
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -128.5,104.5
       parent: 1
-    - type: PointLight
   - uid: 24069
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -124.5,108.5
       parent: 1
-    - type: PointLight
   - uid: 24070
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -122.5,108.5
       parent: 1
-    - type: PointLight
   - uid: 24071
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -118.5,112.5
       parent: 1
-    - type: PointLight
   - uid: 24072
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -115.5,104.5
       parent: 1
-    - type: PointLight
   - uid: 24073
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -113.5,108.5
       parent: 1
-    - type: PointLight
   - uid: 24074
     components:
     - type: Transform
       pos: -114.5,99.5
       parent: 1
-    - type: PointLight
   - uid: 24075
     components:
     - type: Transform
       pos: -105.5,99.5
       parent: 1
-    - type: PointLight
   - uid: 24076
     components:
     - type: Transform
       pos: -109.5,99.5
       parent: 1
-    - type: PointLight
   - uid: 24077
     components:
     - type: Transform
       pos: -103.5,99.5
       parent: 1
-    - type: PointLight
   - uid: 24078
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -105.5,104.5
       parent: 1
-    - type: PointLight
   - uid: 24079
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -103.5,104.5
       parent: 1
-    - type: PointLight
   - uid: 24080
     components:
     - type: Transform
       pos: -103.5,106.5
       parent: 1
-    - type: PointLight
   - uid: 24081
     components:
     - type: Transform
       pos: -108.5,106.5
       parent: 1
-    - type: PointLight
   - uid: 24082
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -100.5,105.5
       parent: 1
-    - type: PointLight
   - uid: 24083
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -97.5,104.5
       parent: 1
-    - type: PointLight
   - uid: 24084
     components:
     - type: Transform
       pos: -95.5,112.5
       parent: 1
-    - type: PointLight
   - uid: 24085
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -100.5,116.5
       parent: 1
-    - type: PointLight
   - uid: 24086
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -108.5,117.5
       parent: 1
-    - type: PointLight
   - uid: 24087
     components:
     - type: Transform
       pos: -107.5,113.5
       parent: 1
-    - type: PointLight
   - uid: 24088
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -110.5,117.5
       parent: 1
-    - type: PointLight
   - uid: 24089
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -86.5,106.5
       parent: 1
-    - type: PointLight
   - uid: 24090
     components:
     - type: Transform
       pos: -105.5,110.5
       parent: 1
-    - type: PointLight
   - uid: 24091
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -117.5,94.5
       parent: 1
-    - type: PointLight
   - uid: 24092
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -120.5,90.5
       parent: 1
-    - type: PointLight
   - uid: 24093
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -115.5,90.5
       parent: 1
-    - type: PointLight
   - uid: 24094
     components:
     - type: Transform
       pos: -118.5,88.5
       parent: 1
-    - type: PointLight
   - uid: 24095
     components:
     - type: Transform
       pos: -120.5,92.5
       parent: 1
-    - type: PointLight
   - uid: 24096
     components:
     - type: Transform
       pos: -115.5,92.5
       parent: 1
-    - type: PointLight
   - uid: 24097
     components:
     - type: Transform
       pos: -113.5,87.5
       parent: 1
-    - type: PointLight
   - uid: 24098
     components:
     - type: Transform
       pos: -109.5,87.5
       parent: 1
-    - type: PointLight
   - uid: 24099
     components:
     - type: Transform
       pos: -108.5,87.5
       parent: 1
-    - type: PointLight
   - uid: 24100
     components:
     - type: Transform
       pos: -102.5,87.5
       parent: 1
-    - type: PointLight
   - uid: 24101
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -101.5,93.5
       parent: 1
-    - type: PointLight
   - uid: 24102
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -111.5,94.5
       parent: 1
-    - type: PointLight
   - uid: 24103
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -103.5,94.5
       parent: 1
-    - type: PointLight
   - uid: 24104
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -99.5,90.5
       parent: 1
-    - type: PointLight
   - uid: 24105
     components:
     - type: Transform
       pos: -99.5,87.5
       parent: 1
-    - type: PointLight
   - uid: 24106
     components:
     - type: Transform
       pos: -95.5,86.5
       parent: 1
-    - type: PointLight
   - uid: 24107
     components:
     - type: Transform
       pos: -92.5,89.5
       parent: 1
-    - type: PointLight
   - uid: 24108
     components:
     - type: Transform
       pos: -92.5,94.5
       parent: 1
-    - type: PointLight
   - uid: 24109
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -92.5,92.5
       parent: 1
-    - type: PointLight
   - uid: 24110
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -86.5,92.5
       parent: 1
-    - type: PointLight
   - uid: 24111
     components:
     - type: Transform
       pos: -86.5,94.5
       parent: 1
-    - type: PointLight
   - uid: 24112
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -83.5,91.5
       parent: 1
-    - type: PointLight
   - uid: 24113
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -95.5,102.5
       parent: 1
-    - type: PointLight
   - uid: 24114
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -97.5,107.5
       parent: 1
-    - type: PointLight
   - uid: 24115
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -93.5,105.5
       parent: 1
-    - type: PointLight
   - uid: 24116
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -94.5,118.5
       parent: 1
-    - type: PointLight
   - uid: 24117
     components:
     - type: Transform
       pos: -90.5,112.5
       parent: 1
-    - type: PointLight
   - uid: 24118
     components:
     - type: Transform
       pos: -86.5,112.5
       parent: 1
-    - type: PointLight
   - uid: 24119
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -86.5,114.5
       parent: 1
-    - type: PointLight
   - uid: 24120
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -83.5,112.5
       parent: 1
-    - type: PointLight
   - uid: 24121
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -92.5,110.5
       parent: 1
-    - type: PointLight
   - uid: 24122
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -82.5,105.5
       parent: 1
-    - type: PointLight
   - uid: 24123
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -91.5,104.5
       parent: 1
-    - type: PointLight
   - uid: 24124
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -91.5,100.5
       parent: 1
-    - type: PointLight
   - uid: 24125
     components:
     - type: Transform
       pos: -86.5,98.5
       parent: 1
-    - type: PointLight
   - uid: 24126
     components:
     - type: Transform
       pos: -82.5,99.5
       parent: 1
-    - type: PointLight
   - uid: 24127
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -79.5,102.5
       parent: 1
-    - type: PointLight
   - uid: 24128
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -76.5,102.5
       parent: 1
-    - type: PointLight
   - uid: 24129
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -78.5,102.5
       parent: 1
-    - type: PointLight
   - uid: 24130
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -81.5,102.5
       parent: 1
-    - type: PointLight
   - uid: 24131
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -76.5,106.5
       parent: 1
-    - type: PointLight
   - uid: 24132
     components:
     - type: Transform
       pos: -80.5,109.5
       parent: 1
-    - type: PointLight
   - uid: 24133
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -74.5,107.5
       parent: 1
-    - type: PointLight
   - uid: 24134
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -78.5,116.5
       parent: 1
-    - type: PointLight
   - uid: 24135
     components:
     - type: Transform
       pos: -87.5,120.5
       parent: 1
-    - type: PointLight
   - uid: 24136
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -89.5,118.5
       parent: 1
-    - type: PointLight
   - uid: 24137
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -89.5,121.5
       parent: 1
-    - type: PointLight
   - uid: 24138
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -81.5,121.5
       parent: 1
-    - type: PointLight
   - uid: 24139
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -84.5,126.5
       parent: 1
-    - type: PointLight
   - uid: 24140
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -89.5,126.5
       parent: 1
-    - type: PointLight
   - uid: 24141
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -81.5,126.5
       parent: 1
-    - type: PointLight
   - uid: 24142
     components:
     - type: Transform
       pos: -77.5,120.5
       parent: 1
-    - type: PointLight
   - uid: 24143
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -74.5,124.5
       parent: 1
-    - type: PointLight
   - uid: 24144
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -68.5,126.5
       parent: 1
-    - type: PointLight
   - uid: 24145
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -64.5,126.5
       parent: 1
-    - type: PointLight
   - uid: 24146
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -64.5,120.5
       parent: 1
-    - type: PointLight
   - uid: 24147
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -64.5,115.5
       parent: 1
-    - type: PointLight
   - uid: 24148
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -63.5,121.5
       parent: 1
-    - type: PointLight
   - uid: 24149
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,121.5
       parent: 1
-    - type: PointLight
   - uid: 24150
     components:
     - type: Transform
       pos: -63.5,114.5
       parent: 1
-    - type: PointLight
   - uid: 24151
     components:
     - type: Transform
       pos: -59.5,114.5
       parent: 1
-    - type: PointLight
   - uid: 24152
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -58.5,120.5
       parent: 1
-    - type: PointLight
   - uid: 24153
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -58.5,115.5
       parent: 1
-    - type: PointLight
   - uid: 24154
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -66.5,120.5
       parent: 1
-    - type: PointLight
   - uid: 24155
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -71.5,120.5
       parent: 1
-    - type: PointLight
   - uid: 24156
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -66.5,118.5
       parent: 1
-    - type: PointLight
   - uid: 24157
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -71.5,118.5
       parent: 1
-    - type: PointLight
   - uid: 24158
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -71.5,114.5
       parent: 1
-    - type: PointLight
   - uid: 24159
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -69.5,114.5
       parent: 1
-    - type: PointLight
   - uid: 24160
     components:
     - type: Transform
       pos: -58.5,111.5
       parent: 1
-    - type: PointLight
   - uid: 24161
     components:
     - type: Transform
       pos: -66.5,111.5
       parent: 1
-    - type: PointLight
   - uid: 24162
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -66.5,109.5
       parent: 1
-    - type: PointLight
   - uid: 24163
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -71.5,109.5
       parent: 1
-    - type: PointLight
   - uid: 24164
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -73.5,101.5
       parent: 1
-    - type: PointLight
   - uid: 24165
     components:
     - type: Transform
       pos: -73.5,103.5
       parent: 1
-    - type: PointLight
   - uid: 24166
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -74.5,97.5
       parent: 1
-    - type: PointLight
   - uid: 24167
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -63.5,96.5
       parent: 1
-    - type: PointLight
   - uid: 24168
     components:
     - type: Transform
       pos: -64.5,99.5
       parent: 1
-    - type: PointLight
   - uid: 24169
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -64.5,105.5
       parent: 1
-    - type: PointLight
   - uid: 24170
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,105.5
       parent: 1
-    - type: PointLight
   - uid: 24171
     components:
     - type: Transform
       pos: -59.5,99.5
       parent: 1
-    - type: PointLight
   - uid: 24172
     components:
     - type: Transform
       pos: -59.5,107.5
       parent: 1
-    - type: PointLight
   - uid: 24173
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,109.5
       parent: 1
-    - type: PointLight
   - uid: 24174
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,97.5
       parent: 1
-    - type: PointLight
   - uid: 24175
     components:
     - type: Transform
       pos: -59.5,95.5
       parent: 1
-    - type: PointLight
   - uid: 24176
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -63.5,108.5
       parent: 1
-    - type: PointLight
   - uid: 24177
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -53.5,105.5
       parent: 1
-    - type: PointLight
   - uid: 24178
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -53.5,99.5
       parent: 1
-    - type: PointLight
   - uid: 24179
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -54.5,95.5
       parent: 1
-    - type: PointLight
   - uid: 24180
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,86.5
       parent: 1
-    - type: PointLight
   - uid: 24181
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -38.5,86.5
       parent: 1
-    - type: PointLight
   - uid: 24182
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -53.5,87.5
       parent: 1
-    - type: PointLight
   - uid: 24183
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -51.5,87.5
       parent: 1
-    - type: PointLight
   - uid: 24184
     components:
     - type: Transform
       pos: -55.5,83.5
       parent: 1
-    - type: PointLight
   - uid: 24185
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -53.5,79.5
       parent: 1
-    - type: PointLight
   - uid: 24186
     components:
     - type: Transform
       pos: -52.5,73.5
       parent: 1
-    - type: PointLight
   - uid: 24187
     components:
     - type: Transform
       pos: -48.5,73.5
       parent: 1
-    - type: PointLight
   - uid: 24188
     components:
     - type: Transform
       pos: -43.5,73.5
       parent: 1
-    - type: PointLight
   - uid: 24189
     components:
     - type: Transform
       pos: -39.5,73.5
       parent: 1
-    - type: PointLight
   - uid: 24190
     components:
     - type: Transform
       pos: -36.5,73.5
       parent: 1
-    - type: PointLight
   - uid: 24191
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -71.5,87.5
       parent: 1
-    - type: PointLight
   - uid: 24192
     components:
     - type: Transform
       pos: -67.5,83.5
       parent: 1
-    - type: PointLight
   - uid: 24193
     components:
     - type: Transform
       pos: -58.5,92.5
       parent: 1
-    - type: PointLight
   - uid: 24194
     components:
     - type: Transform
       pos: -71.5,95.5
       parent: 1
-    - type: PointLight
   - uid: 24195
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -66.5,93.5
       parent: 1
-    - type: PointLight
   - uid: 24196
     components:
     - type: Transform
       pos: -67.5,95.5
       parent: 1
-    - type: PointLight
   - uid: 24197
     components:
     - type: Transform
       pos: -72.5,92.5
       parent: 1
-    - type: PointLight
   - uid: 24198
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -58.5,89.5
       parent: 1
-    - type: PointLight
   - uid: 24199
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -76.5,88.5
       parent: 1
-    - type: PointLight
   - uid: 24200
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -78.5,88.5
       parent: 1
-    - type: PointLight
   - uid: 24201
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -81.5,83.5
       parent: 1
-    - type: PointLight
   - uid: 24202
     components:
     - type: Transform
       pos: -81.5,78.5
       parent: 1
-    - type: PointLight
   - uid: 24203
     components:
     - type: Transform
       pos: -89.5,78.5
       parent: 1
-    - type: PointLight
   - uid: 24204
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -89.5,83.5
       parent: 1
-    - type: PointLight
   - uid: 24205
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -84.5,78.5
       parent: 1
-    - type: PointLight
   - uid: 24206
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -79.5,83.5
       parent: 1
-    - type: PointLight
   - uid: 24207
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -121.5,97.5
       parent: 1
-    - type: PointLight
   - uid: 24208
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -58.5,124.5
       parent: 1
-    - type: PointLight
   - uid: 24209
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -53.5,125.5
       parent: 1
-    - type: PointLight
   - uid: 24210
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -55.5,121.5
       parent: 1
-    - type: PointLight
   - uid: 24211
     components:
     - type: Transform
       pos: -53.5,117.5
       parent: 1
-    - type: PointLight
   - uid: 24212
     components:
     - type: Transform
       pos: -44.5,117.5
       parent: 1
-    - type: PointLight
   - uid: 24213
     components:
     - type: Transform
       pos: -38.5,118.5
       parent: 1
-    - type: PointLight
   - uid: 24214
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -36.5,122.5
       parent: 1
-    - type: PointLight
   - uid: 24215
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,125.5
       parent: 1
-    - type: PointLight
   - uid: 24216
     components:
     - type: Transform
       pos: -37.5,129.5
       parent: 1
-    - type: PointLight
   - uid: 24217
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -52.5,131.5
       parent: 1
-    - type: PointLight
   - uid: 24218
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.5,131.5
       parent: 1
-    - type: PointLight
   - uid: 24219
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -43.5,131.5
       parent: 1
-    - type: PointLight
   - uid: 24220
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,131.5
       parent: 1
-    - type: PointLight
   - uid: 24221
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,131.5
       parent: 1
-    - type: PointLight
   - uid: 24222
     components:
     - type: Transform
       pos: -29.5,129.5
       parent: 1
-    - type: PointLight
   - uid: 24223
     components:
     - type: Transform
       pos: -20.5,129.5
       parent: 1
-    - type: PointLight
   - uid: 24224
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,131.5
       parent: 1
-    - type: PointLight
   - uid: 24225
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,130.5
       parent: 1
-    - type: PointLight
   - uid: 24226
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,130.5
       parent: 1
-    - type: PointLight
   - uid: 24227
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,126.5
       parent: 1
-    - type: PointLight
   - uid: 24228
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,130.5
       parent: 1
-    - type: PointLight
   - uid: 24229
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,130.5
       parent: 1
-    - type: PointLight
   - uid: 24230
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,130.5
       parent: 1
-    - type: PointLight
   - uid: 24231
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,130.5
       parent: 1
-    - type: PointLight
   - uid: 24232
     components:
     - type: Transform
       pos: -5.5,125.5
       parent: 1
-    - type: PointLight
   - uid: 24233
     components:
     - type: Transform
       pos: -13.5,125.5
       parent: 1
-    - type: PointLight
   - uid: 24234
     components:
     - type: Transform
       pos: -9.5,125.5
       parent: 1
-    - type: PointLight
   - uid: 24235
     components:
     - type: Transform
       pos: -2.5,125.5
       parent: 1
-    - type: PointLight
   - uid: 24236
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,127.5
       parent: 1
-    - type: PointLight
   - uid: 24237
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,129.5
       parent: 1
-    - type: PointLight
   - uid: 24238
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,126.5
       parent: 1
-    - type: PointLight
   - uid: 24239
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,124.5
       parent: 1
-    - type: PointLight
   - uid: 24240
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,126.5
       parent: 1
-    - type: PointLight
   - uid: 24241
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,124.5
       parent: 1
-    - type: PointLight
   - uid: 24242
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,121.5
       parent: 1
-    - type: PointLight
   - uid: 24243
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,121.5
       parent: 1
-    - type: PointLight
   - uid: 24244
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,117.5
       parent: 1
-    - type: PointLight
   - uid: 24245
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,117.5
       parent: 1
-    - type: PointLight
   - uid: 24246
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,119.5
       parent: 1
-    - type: PointLight
   - uid: 24247
     components:
     - type: Transform
       pos: 2.5,110.5
       parent: 1
-    - type: PointLight
   - uid: 24248
     components:
     - type: Transform
       pos: -6.5,116.5
       parent: 1
-    - type: PointLight
   - uid: 24249
     components:
     - type: Transform
       pos: -10.5,116.5
       parent: 1
-    - type: PointLight
   - uid: 24250
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,114.5
       parent: 1
-    - type: PointLight
   - uid: 24251
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,114.5
       parent: 1
-    - type: PointLight
   - uid: 24252
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,114.5
       parent: 1
-    - type: PointLight
   - uid: 24253
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,114.5
       parent: 1
-    - type: PointLight
   - uid: 24254
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,123.5
       parent: 1
-    - type: PointLight
   - uid: 24255
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,123.5
       parent: 1
-    - type: PointLight
   - uid: 24256
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,119.5
       parent: 1
-    - type: PointLight
   - uid: 24257
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,116.5
       parent: 1
-    - type: PointLight
   - uid: 24258
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,122.5
       parent: 1
-    - type: PointLight
   - uid: 24259
     components:
     - type: Transform
       pos: -24.5,116.5
       parent: 1
-    - type: PointLight
   - uid: 24260
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,119.5
       parent: 1
-    - type: PointLight
   - uid: 24261
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,114.5
       parent: 1
-    - type: PointLight
   - uid: 24262
     components:
     - type: Transform
       pos: -23.5,112.5
       parent: 1
-    - type: PointLight
   - uid: 24263
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -35.5,94.5
       parent: 1
-    - type: PointLight
   - uid: 24264
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -35.5,110.5
       parent: 1
-    - type: PointLight
   - uid: 24265
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,79.5
       parent: 1
-    - type: PointLight
   - uid: 24266
     components:
     - type: Transform
       pos: -36.5,82.5
       parent: 1
-    - type: PointLight
   - uid: 24267
     components:
     - type: Transform
       pos: -34.5,90.5
       parent: 1
-    - type: PointLight
   - uid: 24268
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,88.5
       parent: 1
-    - type: PointLight
   - uid: 24269
     components:
     - type: Transform
       pos: -24.5,82.5
       parent: 1
-    - type: PointLight
   - uid: 24270
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,85.5
       parent: 1
-    - type: PointLight
   - uid: 24271
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,80.5
       parent: 1
-    - type: PointLight
   - uid: 24272
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -36.5,75.5
       parent: 1
-    - type: PointLight
   - uid: 24273
     components:
     - type: Transform
       pos: -20.5,73.5
       parent: 1
-    - type: PointLight
   - uid: 24274
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,75.5
       parent: 1
-    - type: PointLight
   - uid: 24275
     components:
     - type: Transform
       pos: -29.5,73.5
       parent: 1
-    - type: PointLight
   - uid: 24276
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,75.5
       parent: 1
-    - type: PointLight
   - uid: 24277
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,81.5
       parent: 1
-    - type: PointLight
   - uid: 24278
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,88.5
       parent: 1
-    - type: PointLight
   - uid: 24279
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,92.5
       parent: 1
-    - type: PointLight
   - uid: 24280
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,92.5
       parent: 1
-    - type: PointLight
   - uid: 24281
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,100.5
       parent: 1
-    - type: PointLight
   - uid: 24282
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,103.5
       parent: 1
-    - type: PointLight
   - uid: 24283
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,109.5
       parent: 1
-    - type: PointLight
   - uid: 24284
     components:
     - type: Transform
       pos: -15.5,106.5
       parent: 1
-    - type: PointLight
   - uid: 24285
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,104.5
       parent: 1
-    - type: PointLight
   - uid: 24286
     components:
     - type: Transform
       pos: -6.5,106.5
       parent: 1
-    - type: PointLight
   - uid: 24287
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,104.5
       parent: 1
-    - type: PointLight
   - uid: 24288
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,100.5
       parent: 1
-    - type: PointLight
   - uid: 24289
     components:
     - type: Transform
       pos: -11.5,98.5
       parent: 1
-    - type: PointLight
   - uid: 24290
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,96.5
       parent: 1
-    - type: PointLight
   - uid: 24291
     components:
     - type: Transform
       pos: -12.5,90.5
       parent: 1
-    - type: PointLight
   - uid: 24292
     components:
     - type: Transform
       pos: -3.5,90.5
       parent: 1
-    - type: PointLight
   - uid: 24293
     components:
     - type: Transform
       pos: 1.5,90.5
       parent: 1
-    - type: PointLight
   - uid: 24294
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,88.5
       parent: 1
-    - type: PointLight
   - uid: 24295
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,88.5
       parent: 1
-    - type: PointLight
   - uid: 24296
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,87.5
       parent: 1
-    - type: PointLight
   - uid: 24297
     components:
     - type: Transform
       pos: 1.5,85.5
       parent: 1
-    - type: PointLight
   - uid: 24298
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,87.5
       parent: 1
-    - type: PointLight
   - uid: 24299
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,82.5
       parent: 1
-    - type: PointLight
   - uid: 24300
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,82.5
       parent: 1
-    - type: PointLight
   - uid: 24301
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,82.5
       parent: 1
-    - type: PointLight
   - uid: 24302
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,82.5
       parent: 1
-    - type: PointLight
   - uid: 24303
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,86.5
       parent: 1
-    - type: PointLight
   - uid: 24304
     components:
     - type: Transform
       pos: -13.5,81.5
       parent: 1
-    - type: PointLight
   - uid: 24305
     components:
     - type: Transform
       pos: 12.5,88.5
       parent: 1
-    - type: PointLight
   - uid: 24306
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,90.5
       parent: 1
-    - type: PointLight
   - uid: 24307
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,85.5
       parent: 1
-    - type: PointLight
   - uid: 24308
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,74.5
       parent: 1
-    - type: PointLight
   - uid: 24309
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,69.5
       parent: 1
-    - type: PointLight
   - uid: 24310
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,69.5
       parent: 1
-    - type: PointLight
   - uid: 24311
     components:
     - type: Transform
       pos: 12.5,63.5
       parent: 1
-    - type: PointLight
   - uid: 24312
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,81.5
       parent: 1
-    - type: PointLight
   - uid: 24313
     components:
     - type: Transform
       pos: 26.5,79.5
       parent: 1
-    - type: PointLight
   - uid: 24314
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 33.5,78.5
       parent: 1
-    - type: PointLight
   - uid: 24315
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 33.5,82.5
       parent: 1
-    - type: PointLight
   - uid: 24316
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,84.5
       parent: 1
-    - type: PointLight
   - uid: 24317
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 39.5,84.5
       parent: 1
-    - type: PointLight
   - uid: 24318
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 44.5,83.5
       parent: 1
-    - type: PointLight
   - uid: 24319
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 47.5,77.5
       parent: 1
-    - type: PointLight
   - uid: 24320
     components:
     - type: Transform
       pos: 41.5,72.5
       parent: 1
-    - type: PointLight
   - uid: 24321
     components:
     - type: Transform
       pos: 36.5,72.5
       parent: 1
-    - type: PointLight
   - uid: 24322
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,94.5
       parent: 1
-    - type: PointLight
   - uid: 24323
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 48.5,105.5
       parent: 1
-    - type: PointLight
   - uid: 24324
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,98.5
       parent: 1
-    - type: PointLight
   - uid: 24325
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,108.5
       parent: 1
-    - type: PointLight
   - uid: 24326
     components:
     - type: Transform
       pos: 25.5,110.5
       parent: 1
-    - type: PointLight
   - uid: 24327
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,112.5
       parent: 1
-    - type: PointLight
   - uid: 24328
     components:
     - type: Transform
       pos: 13.5,110.5
       parent: 1
-    - type: PointLight
   - uid: 24329
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,107.5
       parent: 1
-    - type: PointLight
   - uid: 24330
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,106.5
       parent: 1
-    - type: PointLight
   - uid: 24331
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,103.5
       parent: 1
-    - type: PointLight
   - uid: 24332
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,101.5
       parent: 1
-    - type: PointLight
   - uid: 24333
     components:
     - type: Transform
       pos: 13.5,97.5
       parent: 1
-    - type: PointLight
   - uid: 24334
     components:
     - type: Transform
       pos: 8.5,99.5
       parent: 1
-    - type: PointLight
   - uid: 24335
     components:
     - type: Transform
       pos: 4.5,101.5
       parent: 1
-    - type: PointLight
   - uid: 24336
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,103.5
       parent: 1
-    - type: PointLight
   - uid: 24337
     components:
     - type: Transform
       pos: 1.5,105.5
       parent: 1
-    - type: PointLight
   - uid: 24338
     components:
     - type: Transform
       pos: 2.5,97.5
       parent: 1
-    - type: PointLight
   - uid: 24339
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,107.5
       parent: 1
-    - type: PointLight
   - uid: 24340
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,98.5
       parent: 1
-    - type: PointLight
   - uid: 24341
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,97.5
       parent: 1
-    - type: PointLight
   - uid: 24342
     components:
     - type: Transform
       pos: -3.5,94.5
       parent: 1
-    - type: PointLight
   - uid: 24343
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,92.5
       parent: 1
-    - type: PointLight
   - uid: 24344
     components:
     - type: Transform
       pos: -2.5,106.5
       parent: 1
-    - type: PointLight
   - uid: 24345
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,110.5
       parent: 1
-    - type: PointLight
   - uid: 24346
     components:
     - type: Transform
       pos: -11.5,112.5
       parent: 1
-    - type: PointLight
   - uid: 24347
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,119.5
       parent: 1
-    - type: PointLight
   - uid: 24348
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,125.5
       parent: 1
-    - type: PointLight
   - uid: 24349
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,130.5
       parent: 1
-    - type: PointLight
   - uid: 24350
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,141.5
       parent: 1
-    - type: PointLight
   - uid: 24351
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,135.5
       parent: 1
-    - type: PointLight
   - uid: 24352
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,135.5
       parent: 1
-    - type: PointLight
   - uid: 24353
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 33.5,126.5
       parent: 1
-    - type: PointLight
   - uid: 24354
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,132.5
       parent: 1
-    - type: PointLight
   - uid: 24355
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 41.5,132.5
       parent: 1
-    - type: PointLight
   - uid: 24356
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 47.5,129.5
       parent: 1
-    - type: PointLight
   - uid: 24357
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 44.5,123.5
       parent: 1
-    - type: PointLight
   - uid: 24358
     components:
     - type: Transform
       pos: 39.5,120.5
       parent: 1
-    - type: PointLight
   - uid: 24359
     components:
     - type: Transform
       pos: 35.5,120.5
       parent: 1
-    - type: PointLight
   - uid: 24360
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 33.5,122.5
       parent: 1
-    - type: PointLight
   - uid: 24361
     components:
     - type: Transform
       pos: 37.5,110.5
       parent: 1
-    - type: PointLight
   - uid: 24362
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,112.5
       parent: 1
-    - type: PointLight
   - uid: 24363
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,112.5
       parent: 1
-    - type: PointLight
   - uid: 24364
     components:
     - type: Transform
       pos: 68.5,114.5
       parent: 1
-    - type: PointLight
   - uid: 24365
     components:
     - type: Transform
       pos: 68.5,118.5
       parent: 1
-    - type: PointLight
   - uid: 24366
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 65.5,116.5
       parent: 1
-    - type: PointLight
   - uid: 24367
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 71.5,115.5
       parent: 1
-    - type: PointLight
   - uid: 24368
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 75.5,112.5
       parent: 1
-    - type: PointLight
   - uid: 24369
     components:
     - type: Transform
       pos: 75.5,114.5
       parent: 1
-    - type: PointLight
   - uid: 24370
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 78.5,116.5
       parent: 1
-    - type: PointLight
   - uid: 24371
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 84.5,116.5
       parent: 1
-    - type: PointLight
   - uid: 24372
     components:
     - type: Transform
       pos: 76.5,118.5
       parent: 1
-    - type: PointLight
   - uid: 24373
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 85.5,122.5
       parent: 1
-    - type: PointLight
   - uid: 24374
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 92.5,121.5
       parent: 1
-    - type: PointLight
   - uid: 24375
     components:
     - type: Transform
       pos: 98.5,119.5
       parent: 1
-    - type: PointLight
   - uid: 24376
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 103.5,121.5
       parent: 1
-    - type: PointLight
   - uid: 24377
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 94.5,106.5
       parent: 1
-    - type: PointLight
   - uid: 24378
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 97.5,106.5
       parent: 1
-    - type: PointLight
   - uid: 24379
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 108.5,106.5
       parent: 1
-    - type: PointLight
   - uid: 24380
     components:
     - type: Transform
       pos: 104.5,104.5
       parent: 1
-    - type: PointLight
   - uid: 24381
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 103.5,100.5
       parent: 1
-    - type: PointLight
   - uid: 24382
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 113.5,105.5
       parent: 1
-    - type: PointLight
   - uid: 24383
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 113.5,99.5
       parent: 1
-    - type: PointLight
   - uid: 24384
     components:
     - type: Transform
       pos: 108.5,98.5
       parent: 1
-    - type: PointLight
   - uid: 24385
     components:
     - type: Transform
       pos: 99.5,98.5
       parent: 1
-    - type: PointLight
   - uid: 24386
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 97.5,98.5
       parent: 1
-    - type: PointLight
   - uid: 24387
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 94.5,98.5
       parent: 1
-    - type: PointLight
   - uid: 24388
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 90.5,102.5
       parent: 1
-    - type: PointLight
   - uid: 24389
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 88.5,98.5
       parent: 1
-    - type: PointLight
   - uid: 24390
     components:
     - type: Transform
       pos: 84.5,95.5
       parent: 1
-    - type: PointLight
   - uid: 24391
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 93.5,85.5
       parent: 1
-    - type: PointLight
   - uid: 24392
     components:
     - type: Transform
       pos: 98.5,83.5
       parent: 1
-    - type: PointLight
   - uid: 24393
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 103.5,85.5
       parent: 1
-    - type: PointLight
   - uid: 24394
     components:
     - type: Transform
       pos: 85.5,82.5
       parent: 1
-    - type: PointLight
   - uid: 24395
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 70.5,90.5
       parent: 1
-    - type: PointLight
   - uid: 24396
     components:
     - type: Transform
       pos: 67.5,92.5
       parent: 1
-    - type: PointLight
   - uid: 24397
     components:
     - type: Transform
       pos: 73.5,92.5
       parent: 1
-    - type: PointLight
   - uid: 24398
     components:
     - type: Transform
       pos: 70.5,88.5
       parent: 1
-    - type: PointLight
   - uid: 24399
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,85.5
       parent: 1
-    - type: PointLight
   - uid: 24400
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 59.5,89.5
       parent: 1
-    - type: PointLight
   - uid: 24401
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 58.5,85.5
       parent: 1
-    - type: PointLight
   - uid: 24402
     components:
     - type: Transform
       pos: 61.5,92.5
       parent: 1
-    - type: PointLight
   - uid: 24403
     components:
     - type: Transform
       pos: 50.5,92.5
       parent: 1
-    - type: PointLight
   - uid: 24404
     components:
     - type: Transform
       pos: 44.5,92.5
       parent: 1
-    - type: PointLight
   - uid: 24405
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 56.5,94.5
       parent: 1
-    - type: PointLight
   - uid: 24406
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 58.5,98.5
       parent: 1
-    - type: PointLight
   - uid: 24407
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 54.5,107.5
       parent: 1
-    - type: PointLight
   - uid: 24408
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 58.5,104.5
       parent: 1
-    - type: PointLight
   - uid: 24409
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 64.5,108.5
       parent: 1
-    - type: PointLight
   - uid: 24410
     components:
     - type: Transform
       pos: 66.5,110.5
       parent: 1
-    - type: PointLight
   - uid: 24411
     components:
     - type: Transform
       pos: 64.5,100.5
       parent: 1
-    - type: PointLight
   - uid: 24412
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 65.5,97.5
       parent: 1
-    - type: PointLight
   - uid: 24413
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 72.5,98.5
       parent: 1
-    - type: PointLight
   - uid: 24414
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 64.5,94.5
       parent: 1
-    - type: PointLight
   - uid: 24415
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 78.5,96.5
       parent: 1
-    - type: PointLight
   - uid: 24416
     components:
     - type: Transform
       pos: 72.5,100.5
       parent: 1
-    - type: PointLight
   - uid: 24417
     components:
     - type: Transform
       pos: 76.5,100.5
       parent: 1
-    - type: PointLight
   - uid: 24418
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 72.5,104.5
       parent: 1
-    - type: PointLight
   - uid: 24419
     components:
     - type: Transform
       pos: 72.5,106.5
       parent: 1
-    - type: PointLight
   - uid: 24420
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 78.5,108.5
       parent: 1
-    - type: PointLight
   - uid: 24421
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,94.5
       parent: 1
-    - type: PointLight
   - uid: 24422
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 60.5,97.5
       parent: 1
-    - type: PointLight
   - uid: 24423
     components:
     - type: Transform
       pos: 63.5,126.5
       parent: 1
-    - type: PointLight
   - uid: 24424
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -54.5,109.5
       parent: 1
-    - type: PointLight
   - uid: 24425
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -76.5,98.5
       parent: 1
-    - type: PointLight
   - uid: 24426
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -80.5,95.5
       parent: 1
-    - type: PointLight
   - uid: 24427
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 48.5,124.5
       parent: 1
-    - type: PointLight
   - uid: 24428
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-33.5
       parent: 1
-    - type: PointLight
   - uid: 24429
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-30.5
       parent: 1
-    - type: PointLight
   - uid: 24430
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-33.5
       parent: 1
-    - type: PointLight
   - uid: 24431
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-28.5
       parent: 1
-    - type: PointLight
   - uid: 24432
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -83.5,0.5
       parent: 1
-    - type: PointLight
   - uid: 24433
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -81.5,0.5
       parent: 1
-    - type: PointLight
   - uid: 24434
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 85.5,2.5
       parent: 1
-    - type: PointLight
   - uid: 24435
     components:
     - type: Transform
       pos: 85.5,-3.5
       parent: 1
-    - type: PointLight
   - uid: 24436
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 77.5,-0.5
       parent: 1
-    - type: PointLight
   - uid: 24437
     components:
     - type: Transform
       pos: -43.5,-14.5
       parent: 1
-    - type: PointLight
   - uid: 24438
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 59.5,-16.5
       parent: 1
-    - type: PointLight
   - uid: 24439
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -54.5,-18.5
       parent: 1
-    - type: PointLight
   - uid: 24440
     components:
     - type: Transform
       pos: 88.5,106.5
       parent: 1
-    - type: PointLight
   - uid: 24441
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 84.5,109.5
       parent: 1
-    - type: PointLight
   - uid: 24442
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 81.5,104.5
       parent: 1
-    - type: PointLight
   - uid: 24443
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 81.5,100.5
       parent: 1
-    - type: PointLight
   - uid: 24444
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 84.5,100.5
       parent: 1
-    - type: PointLight
   - uid: 24445
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 84.5,104.5
       parent: 1
-    - type: PointLight
   - uid: 24446
     components:
     - type: Transform
       pos: 26.5,123.5
       parent: 1
-    - type: PointLight
   - uid: 24447
     components:
     - type: Transform
       pos: -74.5,80.5
       parent: 1
-    - type: PointLight
   - uid: 24448
     components:
     - type: Transform
       pos: -64.5,78.5
       parent: 1
-    - type: PointLight
   - uid: 24449
     components:
     - type: Transform
       pos: -68.5,78.5
       parent: 1
-    - type: PointLight
   - uid: 24450
     components:
     - type: Transform
       pos: -58.5,80.5
       parent: 1
-    - type: PointLight
   - uid: 24451
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 71.5,4.5
       parent: 1
-    - type: PointLight
   - uid: 24452
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 71.5,-5.5
       parent: 1
-    - type: PointLight
   - uid: 24453
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,25.5
       parent: 1
-    - type: PointLight
   - uid: 24454
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,25.5
       parent: 1
-    - type: PointLight
   - uid: 24455
     components:
     - type: Transform
       pos: -19.5,-13.5
       parent: 1
-    - type: PointLight
   - uid: 24456
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,-28.5
       parent: 1
-    - type: PointLight
   - uid: 24457
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,92.5
       parent: 1
-    - type: PointLight
   - uid: 24458
     components:
     - type: Transform
       pos: 43.5,-13.5
       parent: 1
-    - type: PointLight
   - uid: 24459
     components:
     - type: Transform
       pos: -50.5,-17.5
       parent: 1
-    - type: PointLight
   - uid: 24460
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,12.5
       parent: 1
-    - type: PointLight
   - uid: 24461
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 100.5,107.5
       parent: 1
-    - type: PointLight
   - uid: 24462
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 107.5,107.5
       parent: 1
-    - type: PointLight
   - uid: 24463
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 107.5,97.5
       parent: 1
-    - type: PointLight
   - uid: 24464
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 100.5,97.5
       parent: 1
-    - type: PointLight
   - uid: 24465
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 99.5,106.5
       parent: 1
-    - type: PointLight
   - uid: 24466
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -116.5,108.5
       parent: 1
-    - type: PointLight
   - uid: 24467
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -109.5,111.5
       parent: 1
-    - type: PointLight
   - uid: 24468
     components:
     - type: Transform
       pos: -30.5,-13.5
       parent: 1
-    - type: PointLight
   - uid: 24469
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 65.5,124.5
       parent: 1
-    - type: PointLight
   - uid: 24470
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 77.5,1.5
       parent: 1
-    - type: PointLight
   - uid: 24471
     components:
     - type: Transform
       pos: 77.5,-2.5
       parent: 1
-    - type: PointLight
   - uid: 24472
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 45.5,112.5
       parent: 1
-    - type: PointLight
   - uid: 24473
     components:
     - type: Transform
       pos: 23.5,101.5
       parent: 1
-    - type: PointLight
   - uid: 24474
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,15.5
       parent: 1
-    - type: PointLight
   - uid: 24475
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 47.5,-26.5
       parent: 1
-    - type: PointLight
   - uid: 24476
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,15.5
       parent: 1
-    - type: PointLight
   - uid: 24477
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,17.5
       parent: 1
-    - type: PointLight
   - uid: 24478
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,15.5
       parent: 1
-    - type: PointLight
   - uid: 24479
     components:
     - type: Transform
       pos: 46.5,18.5
       parent: 1
-    - type: PointLight
   - uid: 24480
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 47.5,17.5
       parent: 1
-    - type: PointLight
   - uid: 24481
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 42.5,15.5
       parent: 1
-    - type: PointLight
   - uid: 24482
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 42.5,27.5
       parent: 1
-    - type: PointLight
   - uid: 24483
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 46.5,24.5
       parent: 1
-    - type: PointLight
   - uid: 24484
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 41.5,24.5
       parent: 1
-    - type: PointLight
   - uid: 24485
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,25.5
       parent: 1
-    - type: PointLight
   - uid: 24486
     components:
     - type: Transform
       pos: 41.5,18.5
       parent: 1
-    - type: PointLight
   - uid: 24487
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,27.5
       parent: 1
-    - type: PointLight
   - uid: 24488
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,27.5
       parent: 1
-    - type: PointLight
   - uid: 24489
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 47.5,25.5
       parent: 1
-    - type: PointLight
   - uid: 24490
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-16.5
       parent: 1
-    - type: PointLight
   - uid: 24491
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 47.5,-18.5
       parent: 1
-    - type: PointLight
   - uid: 24492
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 46.5,-19.5
       parent: 1
-    - type: PointLight
   - uid: 24493
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 41.5,-19.5
       parent: 1
-    - type: PointLight
   - uid: 24494
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 42.5,-16.5
       parent: 1
-    - type: PointLight
   - uid: 24495
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,-28.5
       parent: 1
-    - type: PointLight
   - uid: 24496
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 42.5,-28.5
       parent: 1
-    - type: PointLight
   - uid: 24497
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-28.5
       parent: 1
-    - type: PointLight
   - uid: 24498
     components:
     - type: Transform
       pos: 46.5,-25.5
       parent: 1
-    - type: PointLight
   - uid: 24499
     components:
     - type: Transform
       pos: 41.5,-25.5
       parent: 1
-    - type: PointLight
   - uid: 24500
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -72.5,106.5
       parent: 1
-    - type: PointLight
   - uid: 24501
     components:
     - type: Transform
       pos: -72.5,98.5
       parent: 1
-    - type: PointLight
   - uid: 24502
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -86.5,110.5
       parent: 1
-    - type: PointLight
   - uid: 24503
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -81.5,97.5
       parent: 1
-    - type: PointLight
   - uid: 24504
     components:
     - type: Transform
       pos: -81.5,107.5
       parent: 1
-    - type: PointLight
   - uid: 24505
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -100.5,113.5
       parent: 1
-    - type: PointLight
   - uid: 24506
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -99.5,95.5
       parent: 1
-    - type: PointLight
   - uid: 24507
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 70.5,86.5
       parent: 1
-    - type: PointLight
   - uid: 24508
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,109.5
       parent: 1
-    - type: PointLight
   - uid: 24509
     components:
     - type: Transform
       pos: -27.5,94.5
       parent: 1
-    - type: PointLight
   - uid: 24510
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,94.5
       parent: 1
-    - type: PointLight
   - uid: 24511
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,94.5
       parent: 1
-    - type: PointLight
   - uid: 24512
     components:
     - type: Transform
       pos: -63.5,2.5
       parent: 1
-    - type: PointLight
   - uid: 24513
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,98.5
       parent: 1
-    - type: PointLight
   - uid: 24514
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,96.5
       parent: 1
-    - type: PointLight
   - uid: 24515
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,98.5
       parent: 1
-    - type: PointLight
   - uid: 24516
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,98.5
       parent: 1
-    - type: PointLight
   - uid: 24517
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,107.5
       parent: 1
-    - type: PointLight
   - uid: 24518
     components:
     - type: Transform
       pos: -7.5,77.5
       parent: 1
-    - type: PointLight
   - uid: 24519
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,97.5
       parent: 1
-    - type: PointLight
   - uid: 24520
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,107.5
       parent: 1
-    - type: PointLight
   - uid: 24521
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,97.5
       parent: 1
-    - type: PointLight
   - uid: 24522
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,102.5
       parent: 1
-    - type: PointLight
   - uid: 24523
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,110.5
       parent: 1
-    - type: PointLight
   - uid: 24524
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,110.5
       parent: 1
-    - type: PointLight
   - uid: 24525
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,107.5
       parent: 1
-    - type: PointLight
   - uid: 24526
     components:
     - type: Transform
       pos: -30.5,100.5
       parent: 1
-    - type: PointLight
   - uid: 24527
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,104.5
       parent: 1
-    - type: PointLight
   - uid: 24528
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,8.5
       parent: 1
-    - type: PointLight
   - uid: 24529
     components:
     - type: Transform
       pos: -41.5,10.5
       parent: 1
-    - type: PointLight
   - uid: 24530
     components:
     - type: Transform
       pos: -36.5,10.5
       parent: 1
-    - type: PointLight
   - uid: 24531
     components:
     - type: Transform
       pos: -31.5,-1.5
       parent: 1
-    - type: PointLight
   - uid: 24532
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -42.5,2.5
       parent: 1
-    - type: PointLight
   - uid: 24533
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,-5.5
       parent: 1
-    - type: PointLight
   - uid: 24534
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -35.5,6.5
       parent: 1
-    - type: PointLight
   - uid: 24535
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -35.5,8.5
       parent: 1
-    - type: PointLight
   - uid: 24536
     components:
     - type: Transform
       pos: -19.5,10.5
       parent: 1
-    - type: PointLight
   - uid: 24537
     components:
     - type: Transform
       pos: -18.5,-9.5
       parent: 1
-    - type: PointLight
   - uid: 24538
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,3.5
       parent: 1
-    - type: PointLight
   - uid: 24539
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,4.5
       parent: 1
-    - type: PointLight
   - uid: 24540
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -36.5,3.5
       parent: 1
-    - type: PointLight
   - uid: 24541
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-0.5
       parent: 1
-    - type: PointLight
   - uid: 24542
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,3.5
       parent: 1
-    - type: PointLight
   - uid: 24543
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,8.5
       parent: 1
-    - type: PointLight
   - uid: 24544
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,-0.5
       parent: 1
-    - type: PointLight
   - uid: 24545
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,4.5
       parent: 1
-    - type: PointLight
   - uid: 24546
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-11.5
       parent: 1
-    - type: PointLight
   - uid: 24547
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,-2.5
       parent: 1
-    - type: PointLight
   - uid: 24548
     components:
     - type: Transform
       pos: -23.5,-4.5
       parent: 1
-    - type: PointLight
   - uid: 24549
     components:
     - type: Transform
       pos: -19.5,-4.5
       parent: 1
-    - type: PointLight
   - uid: 24550
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,4.5
       parent: 1
-    - type: PointLight
   - uid: 24551
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 1
-    - type: PointLight
   - uid: 24552
     components:
     - type: Transform
       pos: -26.5,10.5
       parent: 1
-    - type: PointLight
   - uid: 24553
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,8.5
       parent: 1
-    - type: PointLight
   - uid: 24554
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-5.5
       parent: 1
-    - type: PointLight
   - uid: 24555
     components:
     - type: Transform
       pos: -11.5,10.5
       parent: 1
-    - type: PointLight
   - uid: 24556
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,4.5
       parent: 1
-    - type: PointLight
   - uid: 24557
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,0.5
       parent: 1
-    - type: PointLight
   - uid: 24558
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,1.5
       parent: 1
-    - type: PointLight
   - uid: 24559
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,-0.5
       parent: 1
-    - type: PointLight
   - uid: 24560
     components:
     - type: Transform
       pos: -24.5,-9.5
       parent: 1
-    - type: PointLight
   - uid: 24561
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -42.5,4.5
       parent: 1
-    - type: PointLight
   - uid: 24562
     components:
     - type: Transform
       pos: -9.5,-5.5
       parent: 1
-    - type: PointLight
   - uid: 24563
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -44.5,-9.5
       parent: 1
-    - type: PointLight
   - uid: 24564
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -42.5,-5.5
       parent: 1
-    - type: PointLight
   - uid: 24565
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-2.5
       parent: 1
-    - type: PointLight
   - uid: 24566
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,-11.5
       parent: 1
-    - type: PointLight
   - uid: 24567
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-5.5
       parent: 1
-    - type: PointLight
   - uid: 24568
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -44.5,-4.5
       parent: 1
-    - type: PointLight
   - uid: 24569
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -42.5,-3.5
       parent: 1
-    - type: PointLight
   - uid: 24570
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,-0.5
       parent: 1
-    - type: PointLight
   - uid: 24571
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-6.5
       parent: 1
-    - type: PointLight
   - uid: 24572
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -35.5,-9.5
       parent: 1
-    - type: PointLight
   - uid: 24573
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,8.5
       parent: 1
-    - type: PointLight
   - uid: 24574
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -36.5,-4.5
       parent: 1
-    - type: PointLight
   - uid: 24575
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -44.5,3.5
       parent: 1
-    - type: PointLight
   - uid: 24576
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,-7.5
       parent: 1
-    - type: PointLight
   - uid: 24577
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -62.5,19.5
       parent: 1
-    - type: PointLight
   - uid: 24578
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -57.5,17.5
       parent: 1
-    - type: PointLight
   - uid: 24579
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,17.5
       parent: 1
-    - type: PointLight
   - uid: 24580
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -80.5,12.5
       parent: 1
-    - type: PointLight
   - uid: 24581
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -76.5,17.5
       parent: 1
-    - type: PointLight
   - uid: 24582
     components:
     - type: Transform
       pos: -60.5,14.5
       parent: 1
-    - type: PointLight
   - uid: 24583
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -67.5,19.5
       parent: 1
-    - type: PointLight
   - uid: 24584
     components:
     - type: Transform
       pos: -68.5,14.5
       parent: 1
-    - type: PointLight
   - uid: 24585
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -73.5,12.5
       parent: 1
-    - type: PointLight
   - uid: 24586
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 48.5,99.5
       parent: 1
-    - type: PointLight
   - uid: 24587
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -78.5,17.5
       parent: 1
-    - type: PointLight
   - uid: 24588
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -82.5,18.5
       parent: 1
-    - type: PointLight
   - uid: 24589
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 56.5,107.5
       parent: 1
-    - type: PointLight
   - uid: 24590
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 61.5,107.5
       parent: 1
-    - type: PointLight
   - uid: 24591
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,99.5
       parent: 1
-    - type: PointLight
   - uid: 24592
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 57.5,-2.5
       parent: 1
-    - type: PointLight
   - uid: 24593
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 44.5,115.5
       parent: 1
-    - type: PointLight
   - uid: 24594
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 50.5,115.5
       parent: 1
-    - type: PointLight
   - uid: 24595
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 67.5,104.5
       parent: 1
-    - type: PointLight
   - uid: 24596
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 60.5,-2.5
       parent: 1
-    - type: PointLight
   - uid: 24597
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 55.5,3.5
       parent: 1
-    - type: PointLight
   - uid: 24598
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 57.5,2.5
       parent: 1
-    - type: PointLight
   - uid: 24599
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 55.5,-4.5
       parent: 1
-    - type: PointLight
   - uid: 24600
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 57.5,-8.5
       parent: 1
-    - type: PointLight
   - uid: 24601
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 63.5,-5.5
       parent: 1
-    - type: PointLight
   - uid: 24602
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 57.5,7.5
       parent: 1
-    - type: PointLight
   - uid: 24603
     components:
     - type: Transform
       pos: 27.5,101.5
       parent: 1
-    - type: PointLight
   - uid: 24604
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 35.5,106.5
       parent: 1
-    - type: PointLight
   - uid: 24605
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 29.5,106.5
       parent: 1
-    - type: PointLight
   - uid: 24606
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 30.5,100.5
       parent: 1
-    - type: PointLight
   - uid: 24607
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 35.5,98.5
       parent: 1
-    - type: PointLight
   - uid: 24608
     components:
     - type: Transform
       pos: 31.5,96.5
       parent: 1
-    - type: PointLight
   - uid: 24609
     components:
     - type: Transform
       pos: 22.5,96.5
       parent: 1
-    - type: PointLight
   - uid: 24610
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,94.5
       parent: 1
-    - type: PointLight
   - uid: 24611
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 39.5,103.5
       parent: 1
-    - type: PointLight
   - uid: 24612
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 44.5,103.5
       parent: 1
-    - type: PointLight
   - uid: 24613
     components:
     - type: Transform
       pos: 41.5,96.5
       parent: 1
-    - type: PointLight
   - uid: 24614
     components:
     - type: Transform
       pos: 45.5,96.5
       parent: 1
-    - type: PointLight
   - uid: 24615
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 24.5,115.5
       parent: 1
-    - type: PointLight
   - uid: 24616
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,116.5
       parent: 1
-    - type: PointLight
   - uid: 24617
     components:
     - type: Transform
       pos: 21.5,118.5
       parent: 1
-    - type: PointLight
   - uid: 24618
     components:
     - type: Transform
       pos: 27.5,118.5
       parent: 1
-    - type: PointLight
   - uid: 24619
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,115.5
       parent: 1
-    - type: PointLight
   - uid: 24620
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 29.5,87.5
       parent: 1
-    - type: PointLight
   - uid: 24621
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 33.5,89.5
       parent: 1
-    - type: PointLight
   - uid: 24622
     components:
     - type: Transform
       pos: 28.5,83.5
       parent: 1
-    - type: PointLight
   - uid: 24623
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 24.5,84.5
       parent: 1
-    - type: PointLight
   - uid: 24624
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,88.5
       parent: 1
-    - type: PointLight
   - uid: 24625
     components:
     - type: Transform
       pos: 26.5,105.5
       parent: 1
-    - type: PointLight
   - uid: 24626
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -61.5,85.5
       parent: 1
-    - type: PointLight
   - uid: 24627
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -91.5,3.5
       parent: 1
-    - type: PointLight
   - uid: 24628
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -76.5,117.5
       parent: 1
-    - type: PointLight
   - uid: 24629
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -49.5,103.5
       parent: 1
-    - type: PointLight
   - uid: 24630
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -37.5,105.5
       parent: 1
-    - type: PointLight
   - uid: 24631
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -37.5,99.5
       parent: 1
-    - type: PointLight
   - uid: 24632
     components:
     - type: Transform
       pos: -40.5,89.5
       parent: 1
-    - type: PointLight
   - uid: 24633
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,96.5
       parent: 1
-    - type: PointLight
   - uid: 24634
     components:
     - type: Transform
       pos: -50.5,92.5
       parent: 1
-    - type: PointLight
   - uid: 24635
     components:
     - type: Transform
       pos: -49.5,101.5
       parent: 1
-    - type: PointLight
   - uid: 24636
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -48.5,108.5
       parent: 1
-    - type: PointLight
   - uid: 24637
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -46.5,111.5
       parent: 1
-    - type: PointLight
   - uid: 24638
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -45.5,109.5
       parent: 1
-    - type: PointLight
   - uid: 24639
     components:
     - type: Transform
       pos: -40.5,101.5
       parent: 1
-    - type: PointLight
   - uid: 24640
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -51.5,111.5
       parent: 1
-    - type: PointLight
   - uid: 24641
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -74.5,118.5
       parent: 1
-    - type: PointLight
   - uid: 24642
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,106.5
       parent: 1
-    - type: PointLight
   - uid: 24643
     components:
     - type: Transform
       pos: -41.5,105.5
       parent: 1
-    - type: PointLight
   - uid: 24644
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -47.5,97.5
       parent: 1
-    - type: PointLight
   - uid: 24645
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -39.5,96.5
       parent: 1
-    - type: PointLight
   - uid: 24646
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -52.5,95.5
       parent: 1
-    - type: PointLight
   - uid: 24647
     components:
     - type: Transform
       pos: -51.5,89.5
       parent: 1
-    - type: PointLight
   - uid: 24648
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -64.5,90.5
       parent: 1
-    - type: PointLight
   - uid: 24649
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -61.5,89.5
       parent: 1
-    - type: PointLight
   - uid: 24650
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -58.5,84.5
       parent: 1
-    - type: PointLight
   - uid: 24651
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -94.5,13.5
       parent: 1
-    - type: PointLight
   - uid: 24652
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -91.5,13.5
       parent: 1
-    - type: PointLight
   - uid: 24653
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -97.5,14.5
       parent: 1
-    - type: PointLight
   - uid: 24654
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -98.5,10.5
       parent: 1
-    - type: PointLight
   - uid: 24655
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -102.5,9.5
       parent: 1
-    - type: PointLight
   - uid: 24656
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -102.5,5.5
       parent: 1
-    - type: PointLight
   - uid: 24657
     components:
     - type: Transform
       pos: -98.5,5.5
       parent: 1
-    - type: PointLight
   - uid: 24658
     components:
     - type: Transform
       pos: -92.5,5.5
       parent: 1
-    - type: PointLight
   - uid: 24659
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -91.5,9.5
       parent: 1
-    - type: PointLight
   - uid: 24660
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 44.5,89.5
       parent: 1
-    - type: PointLight
   - uid: 24661
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 50.5,89.5
       parent: 1
-    - type: PointLight
   - uid: 24662
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,8.5
       parent: 1
-    - type: PointLight
   - uid: 24663
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-18.5
       parent: 1
-    - type: PointLight
   - uid: 24664
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,-16.5
       parent: 1
-    - type: PointLight
   - uid: 24665
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,-15.5
       parent: 1
-    - type: PointLight
   - uid: 24666
     components:
     - type: Transform
       pos: -40.5,-19.5
       parent: 1
-    - type: PointLight
   - uid: 24667
     components:
     - type: Transform
       pos: -35.5,-21.5
       parent: 1
-    - type: PointLight
   - uid: 24668
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -36.5,-23.5
       parent: 1
-    - type: PointLight
   - uid: 24669
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,-23.5
       parent: 1
-    - type: PointLight
   - uid: 24670
     components:
     - type: Transform
       pos: -29.5,-26.5
       parent: 1
-    - type: PointLight
   - uid: 24671
     components:
     - type: Transform
       pos: -36.5,-26.5
       parent: 1
-    - type: PointLight
 - proto: RMCLightFixtureBlueDouble
   entities:
   - uid: 24672
@@ -179462,27 +179036,23 @@ entities:
       rot: 3.141592653589793 rad
       pos: -26.5,104.5
       parent: 1
-    - type: PointLight
   - uid: 24673
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -21.5,103.5
       parent: 1
-    - type: PointLight
   - uid: 24674
     components:
     - type: Transform
       pos: -26.5,100.5
       parent: 1
-    - type: PointLight
   - uid: 24675
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -21.5,101.5
       parent: 1
-    - type: PointLight
 - proto: RMCLightFixtureDoubleAlwaysPowered
   entities:
   - uid: 24676
@@ -179491,104 +179061,89 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 121.5,46.5
       parent: 1
-    - type: PointLight
   - uid: 24677
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 119.5,46.5
       parent: 1
-    - type: PointLight
   - uid: 24678
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 128.5,53.5
       parent: 1
-    - type: PointLight
   - uid: 24679
     components:
     - type: Transform
       pos: 128.5,55.5
       parent: 1
-    - type: PointLight
   - uid: 24680
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 117.5,59.5
       parent: 1
-    - type: PointLight
   - uid: 24681
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 123.5,59.5
       parent: 1
-    - type: PointLight
   - uid: 24682
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 130.5,60.5
       parent: 1
-    - type: PointLight
   - uid: 24683
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 114.5,51.5
       parent: 1
-    - type: PointLight
   - uid: 24684
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 119.5,52.5
       parent: 1
-    - type: PointLight
   - uid: 24685
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 121.5,52.5
       parent: 1
-    - type: PointLight
   - uid: 24686
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 130.5,54.5
       parent: 1
-    - type: PointLight
   - uid: 24687
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 117.5,47.5
       parent: 1
-    - type: PointLight
   - uid: 24688
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 123.5,47.5
       parent: 1
-    - type: PointLight
   - uid: 24689
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 129.5,49.5
       parent: 1
-    - type: PointLight
   - uid: 24690
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 126.5,51.5
       parent: 1
-    - type: PointLight
 - proto: RMCLightFixtureSmall
   entities:
   - uid: 24691
@@ -182242,191 +181797,267 @@ entities:
     - type: Transform
       pos: -110.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25158
     components:
     - type: Transform
       pos: -109.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25159
     components:
     - type: Transform
       pos: -107.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25160
     components:
     - type: Transform
       pos: -106.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25161
     components:
     - type: Transform
       pos: -104.5,-7.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25162
     components:
     - type: Transform
       pos: -104.5,-7.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25163
     components:
     - type: Transform
       pos: -104.5,-7.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25164
     components:
     - type: Transform
       pos: -106.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25165
     components:
     - type: Transform
       pos: -106.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25166
     components:
     - type: Transform
       pos: -106.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25167
     components:
     - type: Transform
       pos: -107.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25168
     components:
     - type: Transform
       pos: -107.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25169
     components:
     - type: Transform
       pos: -107.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25170
     components:
     - type: Transform
       pos: -107.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25171
     components:
     - type: Transform
       pos: -107.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25172
     components:
     - type: Transform
       pos: -109.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25173
     components:
     - type: Transform
       pos: -109.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25174
     components:
     - type: Transform
       pos: -109.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25175
     components:
     - type: Transform
       pos: -109.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25176
     components:
     - type: Transform
       pos: -110.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25177
     components:
     - type: Transform
       pos: -110.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25178
     components:
     - type: Transform
       pos: -110.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25179
     components:
     - type: Transform
       pos: -110.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25180
     components:
     - type: Transform
       pos: -110.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25181
     components:
     - type: Transform
       pos: -109.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25182
     components:
     - type: Transform
       pos: -104.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25183
     components:
     - type: Transform
       pos: -104.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25184
     components:
     - type: Transform
       pos: -104.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25185
     components:
     - type: Transform
       pos: -104.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25186
     components:
     - type: Transform
       pos: -104.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25187
     components:
     - type: Transform
       pos: -106.5,-12.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25188
     components:
     - type: Transform
       pos: -105.5,-12.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25189
     components:
     - type: Transform
       pos: -105.5,-12.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25190
     components:
     - type: Transform
       pos: -106.5,-12.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25191
     components:
     - type: Transform
       pos: -106.5,-12.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25192
     components:
     - type: Transform
       pos: -105.5,-12.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25193
     components:
     - type: Transform
       pos: -105.5,-12.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25194
     components:
     - type: Transform
       pos: -106.5,-12.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: RMCOrbitalCannonWarheadSpawner
   entities:
   - uid: 25195
@@ -185263,6 +184894,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: Actingexit
+    - type: Fixtures
+      fixtures: {}
   - uid: 25632
     components:
     - type: Transform
@@ -185270,6 +184903,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: bot_uniforms
+    - type: Fixtures
+      fixtures: {}
   - uid: 25633
     components:
     - type: Transform
@@ -185277,6 +184912,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: asooffice
+    - type: Fixtures
+      fixtures: {}
   - uid: 25634
     components:
     - type: Transform
@@ -185284,6 +184921,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: SSIExit
+    - type: Fixtures
+      fixtures: {}
   - uid: 25635
     components:
     - type: Transform
@@ -185298,6 +184937,8 @@ entities:
       - - CMAccessBrig
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25636
     components:
     - type: Transform
@@ -185312,6 +184953,8 @@ entities:
       - - CMAccessBrig
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25637
     components:
     - type: Transform
@@ -185326,6 +184969,8 @@ entities:
       - - CMAccessBrig
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25638
     components:
     - type: Transform
@@ -185340,6 +184985,8 @@ entities:
       - - CMAccessBrig
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25639
     components:
     - type: Transform
@@ -185355,6 +185002,8 @@ entities:
       - - CMAccessDropship
       - - CMAccessEngineering
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25640
     components:
     - type: Transform
@@ -185369,6 +185018,8 @@ entities:
       - - CMAccessBrig
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25641
     components:
     - type: Transform
@@ -185383,6 +185034,8 @@ entities:
       - - CMAccessBrig
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25642
     components:
     - type: Transform
@@ -185398,6 +185051,8 @@ entities:
       - - CMAccessDropship
       - - CMAccessEngineering
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25643
     components:
     - type: Transform
@@ -185412,6 +185067,8 @@ entities:
       - - CMAccessBrig
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25644
     components:
     - type: Transform
@@ -185426,6 +185083,8 @@ entities:
       - - CMAccessBrig
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25645
     components:
     - type: Transform
@@ -185440,6 +185099,8 @@ entities:
       - - CMAccessBrig
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25646
     components:
     - type: Transform
@@ -185454,6 +185115,8 @@ entities:
       - - CMAccessBrig
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25647
     components:
     - type: Transform
@@ -185468,6 +185131,8 @@ entities:
       - - CMAccessChemistry
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25648
     components:
     - type: MetaData
@@ -185482,6 +185147,8 @@ entities:
       accessKeys: []
       access: []
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25649
     components:
     - type: MetaData
@@ -185496,6 +185163,8 @@ entities:
       accessKeys: []
       access: []
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25650
     components:
     - type: MetaData
@@ -185512,6 +185181,8 @@ entities:
       - - CMAccessChemistry
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25651
     components:
     - type: MetaData
@@ -185528,6 +185199,8 @@ entities:
       - - CMAccessChemistry
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25652
     components:
     - type: Transform
@@ -185543,6 +185216,8 @@ entities:
       - - CMAccessSquadLeaderPrep
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25653
     components:
     - type: MetaData
@@ -185559,6 +185234,8 @@ entities:
       - - CMAccessChemistry
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25654
     components:
     - type: Transform
@@ -185573,6 +185250,8 @@ entities:
       - - CMAccessMedical
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25655
     components:
     - type: MetaData
@@ -185589,6 +185268,8 @@ entities:
       denyTags: []
     - type: RMCPodDoor
       id: souexit2
+    - type: Fixtures
+      fixtures: {}
   - uid: 25656
     components:
     - type: MetaData
@@ -185603,6 +185284,8 @@ entities:
       accessKeys: []
       access: []
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25657
     components:
     - type: MetaData
@@ -185619,6 +185302,8 @@ entities:
       - - CMAccessChemistry
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25658
     components:
     - type: MetaData
@@ -185633,6 +185318,8 @@ entities:
       accessKeys: []
       access: []
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25659
     components:
     - type: MetaData
@@ -185649,6 +185336,8 @@ entities:
       - - CMAccessChemistry
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25660
     components:
     - type: MetaData
@@ -185665,6 +185354,8 @@ entities:
       - - CMAccessChemistry
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25661
     components:
     - type: Transform
@@ -185679,6 +185370,8 @@ entities:
       - - CMAccessChemistry
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25662
     components:
     - type: Transform
@@ -185694,6 +185387,8 @@ entities:
       - - CMAccessSquadLeaderPrep
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25663
     components:
     - type: Transform
@@ -185709,6 +185404,8 @@ entities:
       - - CMAccessSquadLeaderPrep
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25664
     components:
     - type: MetaData
@@ -185725,6 +185422,8 @@ entities:
       - - CMAccessChemistry
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25665
     components:
     - type: Transform
@@ -185739,6 +185438,8 @@ entities:
       - - CMAccessChemistry
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25666
     components:
     - type: Transform
@@ -185753,6 +185454,8 @@ entities:
       - - CMAccessChemistry
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25667
     components:
     - type: MetaData
@@ -185767,6 +185470,8 @@ entities:
       accessKeys: []
       access: []
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25668
     components:
     - type: MetaData
@@ -185781,6 +185486,8 @@ entities:
       accessKeys: []
       access: []
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25669
     components:
     - type: MetaData
@@ -185797,6 +185504,8 @@ entities:
       - - CMAccessChemistry
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25670
     components:
     - type: MetaData
@@ -185813,6 +185522,8 @@ entities:
       - - CMAccessChemistry
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25671
     components:
     - type: Transform
@@ -185827,6 +185538,8 @@ entities:
       - - CMAccessChemistry
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25672
     components:
     - type: Transform
@@ -185842,6 +185555,8 @@ entities:
       - - CMAccessSquadLeaderPrep
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25673
     components:
     - type: MetaData
@@ -185858,6 +185573,8 @@ entities:
       - - CMAccessChemistry
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25674
     components:
     - type: MetaData
@@ -185874,6 +185591,8 @@ entities:
       - - CMAccessChemistry
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25675
     components:
     - type: MetaData
@@ -185890,6 +185609,8 @@ entities:
       - - CMAccessCMO
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25676
     components:
     - type: MetaData
@@ -185906,6 +185627,8 @@ entities:
       - - CMAccessChemistry
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25677
     components:
     - type: MetaData
@@ -185920,6 +185643,8 @@ entities:
       accessKeys: []
       access: []
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25678
     components:
     - type: Transform
@@ -185933,6 +185658,8 @@ entities:
       - - CMAccessSquadLeaderPrep
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25679
     components:
     - type: Transform
@@ -185945,6 +185672,8 @@ entities:
       accessKeys: []
       access: []
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25680
     components:
     - type: MetaData
@@ -185960,6 +185689,8 @@ entities:
       access:
       - - CMAccessBrig
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25681
     components:
     - type: Transform
@@ -185967,6 +185698,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: CMO Shutters
+    - type: Fixtures
+      fixtures: {}
   - uid: 25682
     components:
     - type: Transform
@@ -185974,6 +185707,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: CMO Shutters
+    - type: Fixtures
+      fixtures: {}
   - uid: 25683
     components:
     - type: MetaData
@@ -185989,6 +185724,8 @@ entities:
       access:
       - - CMAccessBrig
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25684
     components:
     - type: MetaData
@@ -186004,6 +185741,8 @@ entities:
       access:
       - - CMAccessBrig
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25685
     components:
     - type: MetaData
@@ -186019,6 +185758,8 @@ entities:
       access:
       - - CMAccessBrig
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25686
     components:
     - type: MetaData
@@ -186036,21 +185777,29 @@ entities:
       - - RMCAccessCommand
       - - CMAccessDropship
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25687
     components:
     - type: Transform
       pos: 26.7,100.8
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25688
     components:
     - type: Transform
       pos: 25.2,104.2
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25689
     components:
     - type: Transform
       pos: 25.2,105.2
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25690
     components:
     - type: Transform
@@ -186066,6 +185815,8 @@ entities:
       - - CMAccessSquadLeaderPrep
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25691
     components:
     - type: Transform
@@ -186081,6 +185832,8 @@ entities:
       - - CMAccessSquadLeaderPrep
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25692
     components:
     - type: Transform
@@ -186096,6 +185849,8 @@ entities:
       - - CMAccessSquadLeaderPrep
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25693
     components:
     - type: Transform
@@ -186108,6 +185863,8 @@ entities:
       accessKeys: []
       access: []
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25694
     components:
     - type: Transform
@@ -186123,6 +185880,8 @@ entities:
       - - CMAccessSquadLeaderPrep
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25695
     components:
     - type: Transform
@@ -186138,6 +185897,8 @@ entities:
       - - CMAccessSquadLeaderPrep
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25696
     components:
     - type: Transform
@@ -186153,6 +185914,8 @@ entities:
       - - CMAccessSquadLeaderPrep
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25697
     components:
     - type: Transform
@@ -186168,6 +185931,8 @@ entities:
       - - CMAccessSquadLeaderPrep
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25698
     components:
     - type: Transform
@@ -186180,6 +185945,8 @@ entities:
       accessKeys: []
       access: []
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25699
     components:
     - type: Transform
@@ -186195,6 +185962,8 @@ entities:
       - - CMAccessSquadLeaderPrep
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25700
     components:
     - type: Transform
@@ -186207,6 +185976,8 @@ entities:
       accessKeys: []
       access: []
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25701
     components:
     - type: Transform
@@ -186219,6 +185990,8 @@ entities:
       accessKeys: []
       access: []
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25702
     components:
     - type: Transform
@@ -186231,6 +186004,8 @@ entities:
       accessKeys: []
       access: []
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25703
     components:
     - type: Transform
@@ -186246,6 +186021,8 @@ entities:
       - - CMAccessSquadLeaderPrep
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25704
     components:
     - type: Transform
@@ -186261,6 +186038,8 @@ entities:
       - - CMAccessSquadLeaderPrep
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25705
     components:
     - type: Transform
@@ -186276,6 +186055,8 @@ entities:
       - - CMAccessSquadLeaderPrep
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25706
     components:
     - type: Transform
@@ -186291,6 +186072,8 @@ entities:
       - - CMAccessSquadLeaderPrep
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25707
     components:
     - type: Transform
@@ -186305,6 +186088,8 @@ entities:
       - - RMCAccessCommand
       - - CMAccessCrewman
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25708
     components:
     - type: Transform
@@ -186318,6 +186103,8 @@ entities:
       access:
       - - CMAccessRequisitions
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25709
     components:
     - type: Transform
@@ -186332,6 +186119,8 @@ entities:
       access:
       - - CMAccessRequisitions
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25710
     components:
     - type: Transform
@@ -186339,6 +186128,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: Tier1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25711
     components:
     - type: Transform
@@ -186346,6 +186137,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: Tier2
+    - type: Fixtures
+      fixtures: {}
   - uid: 25712
     components:
     - type: Transform
@@ -186359,6 +186152,8 @@ entities:
       access:
       - - CMAccessResearch
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25713
     components:
     - type: Transform
@@ -186373,6 +186168,8 @@ entities:
       - - CMAccessResearch
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25714
     components:
     - type: Transform
@@ -186387,6 +186184,8 @@ entities:
       - - CMAccessResearch
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25715
     components:
     - type: Transform
@@ -186401,6 +186200,8 @@ entities:
       - - CMAccessResearch
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25716
     components:
     - type: Transform
@@ -186415,6 +186216,8 @@ entities:
       - - CMAccessResearch
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25717
     components:
     - type: Transform
@@ -186428,6 +186231,8 @@ entities:
       access:
       - - CMAccessResearch
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25718
     components:
     - type: MetaData
@@ -186443,6 +186248,8 @@ entities:
       access:
       - - CMAccessBrig
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25719
     components:
     - type: MetaData
@@ -186458,6 +186265,8 @@ entities:
       access:
       - - CMAccessBrig
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25720
     components:
     - type: MetaData
@@ -186473,6 +186282,8 @@ entities:
       access:
       - - CMAccessBrig
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25721
     components:
     - type: MetaData
@@ -186488,6 +186299,8 @@ entities:
       access:
       - - CMAccessBrig
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25722
     components:
     - type: MetaData
@@ -186503,6 +186316,8 @@ entities:
       access:
       - - CMAccessBrig
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25723
     components:
     - type: MetaData
@@ -186518,6 +186333,8 @@ entities:
       access:
       - - CMAccessArmory
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25724
     components:
     - type: MetaData
@@ -186533,6 +186350,8 @@ entities:
       access:
       - - CMAccessBrig
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25725
     components:
     - type: MetaData
@@ -186548,6 +186367,8 @@ entities:
       access:
       - - CMAccessBrig
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25726
     components:
     - type: MetaData
@@ -186557,6 +186378,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: Brig Lockdown Shutters
+    - type: Fixtures
+      fixtures: {}
   - uid: 25727
     components:
     - type: MetaData
@@ -186573,6 +186396,8 @@ entities:
       - - CMAccessCMP
       - - CMAccessCO
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25728
     components:
     - type: MetaData
@@ -186583,6 +186408,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: Cell3
+    - type: Fixtures
+      fixtures: {}
   - uid: 25729
     components:
     - type: MetaData
@@ -186593,6 +186420,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: Cell2
+    - type: Fixtures
+      fixtures: {}
   - uid: 25730
     components:
     - type: MetaData
@@ -186603,6 +186432,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: Cell1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25731
     components:
     - type: MetaData
@@ -186613,6 +186444,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: Cell4
+    - type: Fixtures
+      fixtures: {}
   - uid: 25732
     components:
     - type: MetaData
@@ -186623,6 +186456,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: Cell5
+    - type: Fixtures
+      fixtures: {}
   - uid: 25733
     components:
     - type: MetaData
@@ -186633,6 +186468,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: Cell6
+    - type: Fixtures
+      fixtures: {}
   - uid: 25734
     components:
     - type: Transform
@@ -186646,6 +186483,8 @@ entities:
       access:
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25735
     components:
     - type: Transform
@@ -186659,6 +186498,8 @@ entities:
       access:
       - - CMAccessRequisitions
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25736
     components:
     - type: Transform
@@ -186672,6 +186513,8 @@ entities:
       access:
       - - CMAccessRequisitions
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25737
     components:
     - type: MetaData
@@ -186687,6 +186530,8 @@ entities:
       access:
       - - RMCAccessSeniorCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25738
     components:
     - type: MetaData
@@ -186702,6 +186547,8 @@ entities:
       access:
       - - RMCAccessSeniorCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25739
     components:
     - type: MetaData
@@ -186718,6 +186565,8 @@ entities:
       - - CMAccessArmory
       - - RMCAccessSeniorCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25740
     components:
     - type: Transform
@@ -186725,6 +186574,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: Under Construction Shutters
+    - type: Fixtures
+      fixtures: {}
   - uid: 25741
     components:
     - type: MetaData
@@ -186740,6 +186591,8 @@ entities:
       access:
       - - CMAccessBrig
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25742
     components:
     - type: Transform
@@ -186747,6 +186600,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: Research_Armory
+    - type: Fixtures
+      fixtures: {}
   - uid: 25743
     components:
     - type: Transform
@@ -186760,6 +186615,8 @@ entities:
       access:
       - - CMAccessResearch
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25744
     components:
     - type: Transform
@@ -186767,6 +186624,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: CE Office Shutters
+    - type: Fixtures
+      fixtures: {}
   - uid: 25745
     components:
     - type: Transform
@@ -186780,6 +186639,8 @@ entities:
       access:
       - - CMAccessResearch
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25746
     components:
     - type: Transform
@@ -186793,6 +186654,8 @@ entities:
       access:
       - - CMAccessResearch
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25747
     components:
     - type: Transform
@@ -186806,6 +186669,8 @@ entities:
       access:
       - - CMAccessResearch
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25748
     components:
     - type: Transform
@@ -186819,111 +186684,155 @@ entities:
       access:
       - - CMAccessResearch
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25749
     components:
     - type: Transform
       pos: 131.25,51.25
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25750
     components:
     - type: Transform
       pos: 131.25,49.75
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25751
     components:
     - type: Transform
       pos: 117.25,48.25
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25752
     components:
     - type: Transform
       pos: 117.25,48.75
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25753
     components:
     - type: Transform
       pos: 118.75,47.75
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25754
     components:
     - type: Transform
       pos: 122.25,47.75
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25755
     components:
     - type: Transform
       pos: 123.75,48.25
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25756
     components:
     - type: Transform
       pos: 123.75,48.75
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25757
     components:
     - type: Transform
       pos: 118.75,49.25
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25758
     components:
     - type: Transform
       pos: 122.25,49.25
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25759
     components:
     - type: Transform
       pos: 118.25,51.25
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25760
     components:
     - type: Transform
       pos: 118.75,51.25
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25761
     components:
     - type: Transform
       pos: 122.75,51.25
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25762
     components:
     - type: Transform
       pos: 122.25,51.25
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25763
     components:
     - type: Transform
       pos: 122.25,54.75
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25764
     components:
     - type: Transform
       pos: 118.75,54.75
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25765
     components:
     - type: Transform
       pos: 118.75,56.25
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25766
     components:
     - type: Transform
       pos: 122.25,56.25
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25767
     components:
     - type: Transform
       pos: 122.25,56.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25768
     components:
     - type: Transform
       pos: 127.75,53.25
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25769
     components:
     - type: Transform
       pos: 127.25,53.25
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25770
     components:
     - type: Transform
@@ -186931,6 +186840,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: tcomms_outer
+    - type: Fixtures
+      fixtures: {}
   - uid: 25771
     components:
     - type: Transform
@@ -186938,6 +186849,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: tcomms_inner
+    - type: Fixtures
+      fixtures: {}
   - uid: 25772
     components:
     - type: Transform
@@ -186945,21 +186858,29 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: tcomms_outer
+    - type: Fixtures
+      fixtures: {}
   - uid: 25773
     components:
     - type: Transform
       pos: 26.8,104.8
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25774
     components:
     - type: Transform
       pos: 26.8,104.2
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25775
     components:
     - type: Transform
       pos: 26.3,100.8
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25776
     components:
     - type: Transform
@@ -186973,6 +186894,8 @@ entities:
       access:
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25777
     components:
     - type: Transform
@@ -186980,6 +186903,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: flightcryo
+    - type: Fixtures
+      fixtures: {}
   - uid: 25778
     components:
     - type: Transform
@@ -186987,6 +186912,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: officers_mess
+    - type: Fixtures
+      fixtures: {}
   - uid: 25779
     components:
     - type: Transform
@@ -187000,6 +186927,8 @@ entities:
       access:
       - - CMAccessCO
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25780
     components:
     - type: Transform
@@ -187007,6 +186936,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: crate_room2
+    - type: Fixtures
+      fixtures: {}
   - uid: 25781
     components:
     - type: Transform
@@ -187014,6 +186945,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: crate_room4
+    - type: Fixtures
+      fixtures: {}
 - proto: RMCPodDoorButtonBigRed
   entities:
   - uid: 25782
@@ -187025,18 +186958,24 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: Brig Lockdown Shutters
+    - type: Fixtures
+      fixtures: {}
   - uid: 25783
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 119.5,59.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25784
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,101.6
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25785
     components:
     - type: Transform
@@ -187044,16 +186983,22 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: engie_store
+    - type: Fixtures
+      fixtures: {}
   - uid: 25786
     components:
     - type: Transform
       pos: -71.2,121.3
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25787
     components:
     - type: Transform
       pos: -71.5,121.3
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: RMCPodDoorButtonShip
   entities:
   - uid: 25788
@@ -187070,6 +187015,8 @@ entities:
       - - CMAccessOT
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25789
     components:
     - type: Transform
@@ -187084,6 +187031,8 @@ entities:
       - - CMAccessOT
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
   - uid: 25790
     components:
     - type: Transform
@@ -187096,6 +187045,8 @@ entities:
       - - CMAccessOT
       - - RMCAccessCommand
       denyTags: []
+    - type: Fixtures
+      fixtures: {}
 - proto: RMCPodDoorButtonWeYa
   entities:
   - uid: 25791
@@ -187105,6 +187056,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: CLRoomDivider
+    - type: Fixtures
+      fixtures: {}
   - uid: 25792
     components:
     - type: Transform
@@ -187112,6 +187065,8 @@ entities:
       parent: 1
     - type: RMCDoorButton
       id: CL_Containment
+    - type: Fixtures
+      fixtures: {}
 - proto: RMCPodDoorButtonWeYaOfficeDoor
   entities:
   - uid: 25793
@@ -187119,16 +187074,22 @@ entities:
     - type: Transform
       pos: -8.5,88.247894
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25794
     components:
     - type: Transform
       pos: -8.5,88.7673
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25795
     components:
     - type: Transform
       pos: -7.65,83.6
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: RMCPodDoorButtonWeYaOfficeEvacPod
   entities:
   - uid: 25796
@@ -187136,6 +187097,8 @@ entities:
     - type: Transform
       pos: -7.65,83.42
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: RMCPodDoorButtonWeYaOfficeMaintenanceDoor
   entities:
   - uid: 25797
@@ -187143,11 +187106,15 @@ entities:
     - type: Transform
       pos: 7.3138647,85.56271
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25798
     components:
     - type: Transform
       pos: 7.7113256,87.32211
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: RMCPodDoorButtonWeYaOfficeQuarterDoor
   entities:
   - uid: 25799
@@ -187155,11 +187122,15 @@ entities:
     - type: Transform
       pos: -3.7,86.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25800
     components:
     - type: Transform
       pos: -3.3,86.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: RMCPodDoorButtonWeYaOfficeQuarterWindows
   entities:
   - uid: 25801
@@ -187167,6 +187138,8 @@ entities:
     - type: Transform
       pos: -1.1531153,88.68472
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: RMCPodDoorButtonWeYaOfficeWindows
   entities:
   - uid: 25802
@@ -187174,6 +187147,8 @@ entities:
     - type: Transform
       pos: -7.65,83.77
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: RMCPortableDialysis
   entities:
   - uid: 25803
@@ -187374,6 +187349,38 @@ entities:
     - type: Transform
       pos: -116.5,5.5
       parent: 1
+- proto: RMCReagentJug
+  entities:
+  - uid: 18413
+    components:
+    - type: Transform
+      pos: -38.5,5.5
+      parent: 1
+  - uid: 18414
+    components:
+    - type: Transform
+      pos: -42.5,5.5
+      parent: 1
+  - uid: 18415
+    components:
+    - type: Transform
+      pos: -34.51414,-21.297161
+      parent: 1
+  - uid: 18416
+    components:
+    - type: Transform
+      pos: -34.51414,-21.64115
+      parent: 1
+  - uid: 18417
+    components:
+    - type: Transform
+      pos: -31.264141,-20.546638
+      parent: 1
+  - uid: 18418
+    components:
+    - type: Transform
+      pos: -31.576641,-20.192226
+      parent: 1
 - proto: RMCRecharger
   entities:
   - uid: 25829
@@ -187457,6 +187464,8 @@ entities:
     - type: Transform
       pos: -46.25,109.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25843
     components:
     - type: MetaData
@@ -187464,6 +187473,8 @@ entities:
     - type: Transform
       pos: 58.25,-4.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25844
     components:
     - type: MetaData
@@ -187471,6 +187482,8 @@ entities:
     - type: Transform
       pos: -42.65,-5.75
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25845
     components:
     - type: MetaData
@@ -187478,6 +187491,8 @@ entities:
     - type: Transform
       pos: -22.65,-9.25
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25846
     components:
     - type: MetaData
@@ -187485,6 +187500,8 @@ entities:
     - type: Transform
       pos: -20.65,8.75
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25847
     components:
     - type: MetaData
@@ -187492,6 +187509,8 @@ entities:
     - type: Transform
       pos: -20.65,-9.25
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25848
     components:
     - type: MetaData
@@ -187499,6 +187518,8 @@ entities:
     - type: Transform
       pos: -31.35,0.75
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25849
     components:
     - type: MetaData
@@ -187506,6 +187527,8 @@ entities:
     - type: Transform
       pos: -22.65,8.75
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25850
     components:
     - type: MetaData
@@ -187513,6 +187536,8 @@ entities:
     - type: Transform
       pos: -7.35,83.6
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25851
     components:
     - type: MetaData
@@ -187520,6 +187545,8 @@ entities:
     - type: Transform
       pos: -100,90.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25852
     components:
     - type: MetaData
@@ -187527,6 +187554,8 @@ entities:
     - type: Transform
       pos: 44.7,89.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25853
     components:
     - type: MetaData
@@ -187534,6 +187563,8 @@ entities:
     - type: Transform
       pos: -64.35,102.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25854
     components:
     - type: MetaData
@@ -187541,6 +187572,8 @@ entities:
     - type: Transform
       pos: -72.5,105.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25855
     components:
     - type: MetaData
@@ -187548,6 +187581,8 @@ entities:
     - type: Transform
       pos: -73.5,103.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25856
     components:
     - type: MetaData
@@ -187555,6 +187590,8 @@ entities:
     - type: Transform
       pos: -73.5,100.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25857
     components:
     - type: MetaData
@@ -187562,6 +187599,8 @@ entities:
     - type: Transform
       pos: -72.5,98.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25858
     components:
     - type: MetaData
@@ -187569,6 +187608,8 @@ entities:
     - type: Transform
       pos: -115,102.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25859
     components:
     - type: MetaData
@@ -187576,6 +187617,8 @@ entities:
     - type: Transform
       pos: -92,90.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25860
     components:
     - type: MetaData
@@ -187583,6 +187626,8 @@ entities:
     - type: Transform
       pos: -55.662525,101.68395
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25861
     components:
     - type: MetaData
@@ -187590,6 +187635,8 @@ entities:
     - type: Transform
       pos: -60.951225,118.53758
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25862
     components:
     - type: MetaData
@@ -187597,6 +187644,8 @@ entities:
     - type: Transform
       pos: -12.194728,98.682076
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25863
     components:
     - type: MetaData
@@ -187604,6 +187653,8 @@ entities:
     - type: Transform
       pos: 126.6,51.25
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25864
     components:
     - type: MetaData
@@ -187611,6 +187662,8 @@ entities:
     - type: Transform
       pos: -70.5,14.75
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25865
     components:
     - type: MetaData
@@ -187618,6 +187671,8 @@ entities:
     - type: Transform
       pos: 35.5,96.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25866
     components:
     - type: MetaData
@@ -187625,6 +187680,8 @@ entities:
     - type: Transform
       pos: 27.5,101.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: RMCRotaryPhoneWallmount
   entities:
   - uid: 25867
@@ -187634,6 +187691,8 @@ entities:
     - type: Transform
       pos: -52.25,98.25
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25868
     components:
     - type: MetaData
@@ -187641,6 +187700,8 @@ entities:
     - type: Transform
       pos: -39.75,9.4
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25869
     components:
     - type: MetaData
@@ -187649,6 +187710,8 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -86.95,126.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25870
     components:
     - type: MetaData
@@ -187656,6 +187719,8 @@ entities:
     - type: Transform
       pos: 72.25,117.4
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25871
     components:
     - type: MetaData
@@ -187663,6 +187728,8 @@ entities:
     - type: Transform
       pos: 36.5,3.4
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25872
     components:
     - type: MetaData
@@ -187671,6 +187738,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 53.95,6.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25873
     components:
     - type: MetaData
@@ -187678,6 +187747,8 @@ entities:
     - type: Transform
       pos: -8.8,-21.6
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25874
     components:
     - type: MetaData
@@ -187686,6 +187757,8 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -24.95,109.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25875
     components:
     - type: MetaData
@@ -187694,6 +187767,8 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -86.95,78.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25876
     components:
     - type: MetaData
@@ -187701,6 +187776,8 @@ entities:
     - type: Transform
       pos: -110.5,112.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25877
     components:
     - type: MetaData
@@ -187709,6 +187786,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -29.05,100.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25878
     components:
     - type: MetaData
@@ -187716,6 +187795,8 @@ entities:
     - type: Transform
       pos: -80.75,20.25
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 25879
     components:
     - type: MetaData
@@ -187724,6 +187805,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -31.05,-17.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: RMCSatchelDemoSpec
   entities:
   - uid: 680
@@ -193327,1056 +193410,1420 @@ entities:
       rot: 3.141592653589793 rad
       pos: 83.5,-8.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26744
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -45.5,99.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26745
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -68.5,83.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26746
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -98.5,7.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26747
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,114.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26748
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -54.5,14.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26749
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -70.5,16.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26750
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -75.5,16.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26751
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -35.5,102.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26752
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,101.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26753
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,78.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26754
     components:
     - type: Transform
       pos: -25.5,97.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26755
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,103.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26756
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,98.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26757
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,108.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26758
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -114.5,115.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26759
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -123.5,113.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26760
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -116.5,116.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26761
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -114.5,110.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26762
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -120.5,120.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26763
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -72.5,102.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26764
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -75.5,102.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26765
     components:
     - type: Transform
       pos: -100.5,117.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26766
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -94.5,115.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26767
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -91.5,121.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26768
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -80.5,118.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26769
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -88.5,112.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26770
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -79.5,110.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26771
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -71.5,126.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26772
     components:
     - type: Transform
       pos: -60.5,112.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26773
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.5,117.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26774
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -53.5,126.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26775
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,126.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26776
     components:
     - type: Transform
       pos: -29.5,114.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26777
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,108.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26778
     components:
     - type: Transform
       pos: -7.5,110.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26779
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,124.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26780
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,125.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26781
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,126.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26782
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,118.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26783
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,123.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26784
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 33.5,128.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26785
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 40.5,120.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26786
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 47.5,128.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26787
     components:
     - type: Transform
       pos: 70.5,120.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26788
     components:
     - type: Transform
       pos: 74.5,116.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26789
     components:
     - type: Transform
       pos: 70.5,112.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26790
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 76.5,108.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26791
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 63.5,107.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26792
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 58.5,104.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26793
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 53.5,100.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26794
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,101.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26795
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 20.5,100.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26796
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,100.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26797
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,104.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26798
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 66.5,100.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26799
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 66.5,92.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26800
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,95.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26801
     components:
     - type: Transform
       pos: 81.5,108.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26802
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 81.5,96.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26803
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 99.5,98.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26804
     components:
     - type: Transform
       pos: 99.5,106.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26805
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 71.5,84.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26806
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 56.5,87.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26807
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 47.5,76.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26808
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 33.5,76.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26809
     components:
     - type: Transform
       pos: 40.5,84.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26810
     components:
     - type: Transform
       pos: 4.5,94.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26811
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,87.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26812
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,99.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26813
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,98.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26814
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,106.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26815
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,102.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26816
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,102.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26817
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,101.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26818
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,96.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26819
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,94.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26820
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,94.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26821
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,74.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26822
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,78.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26823
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -53.5,78.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26824
     components:
     - type: Transform
       pos: -45.5,87.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26825
     components:
     - type: Transform
       pos: -53.5,105.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26826
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -61.5,99.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26827
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -71.5,78.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26828
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -91.5,83.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26829
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -90.5,89.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26830
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -98.5,86.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26831
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -102.5,88.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26832
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -109.5,84.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26833
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -113.5,91.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26834
     components:
     - type: Transform
       pos: -105.5,94.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26835
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -97.5,103.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26836
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -100.5,99.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26837
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -97.5,96.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26838
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -93.5,100.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26839
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -90.5,99.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26840
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -95.5,108.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26841
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -112.5,99.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26842
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -120.5,89.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26843
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -123.5,85.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26844
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -125.5,93.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26845
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -125.5,95.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26846
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -121.5,99.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26847
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -129.5,100.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26848
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -79.5,94.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26849
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -80.5,86.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26850
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -111.5,-2.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26851
     components:
     - type: Transform
       pos: -89.5,19.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26852
     components:
     - type: Transform
       pos: -89.5,-15.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26853
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,-13.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26854
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-17.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26855
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-20.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26856
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,-13.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26857
     components:
     - type: Transform
       pos: 25.5,26.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26858
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,16.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26859
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,22.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26860
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,20.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26861
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,18.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26862
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 49.5,17.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26863
     components:
     - type: Transform
       pos: 49.5,25.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26864
     components:
     - type: Transform
       pos: 36.5,24.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26865
     components:
     - type: Transform
       pos: 85.5,12.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26866
     components:
     - type: Transform
       pos: 83.5,7.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26867
     components:
     - type: Transform
       pos: 92.5,6.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26868
     components:
     - type: Transform
       pos: 102.5,5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26869
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 109.5,-0.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26870
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 102.5,-6.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26871
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 92.5,-7.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26872
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 84.5,-3.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26873
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 85.5,-13.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26874
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 73.5,4.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26875
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 73.5,-5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26876
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 71.5,4.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26877
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 71.5,-5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26878
     components:
     - type: Transform
       pos: 48.5,12.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26879
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,9.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26880
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 31.5,6.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26881
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 31.5,-7.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26882
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,-14.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26883
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,-28.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26884
     components:
     - type: Transform
       pos: 61.5,27.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26885
     components:
     - type: Transform
       pos: 25.5,-17.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26886
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,-27.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26887
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,-25.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26888
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 49.5,-26.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26889
     components:
     - type: Transform
       pos: 49.5,-18.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26890
     components:
     - type: Transform
       pos: 36.5,-19.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26891
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,-21.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26892
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,-23.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26893
     components:
     - type: Transform
       pos: -121.5,109.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26894
     components:
     - type: Transform
       pos: -125.5,109.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26895
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 130.5,54.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26896
     components:
     - type: Transform
       pos: 126.5,53.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26897
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 121.5,49.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26898
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 116.5,52.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26899
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 114.5,44.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26900
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 126.5,44.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26901
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 119.5,47.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26902
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 130.5,60.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26903
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 122.5,57.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26904
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,-6.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26905
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26906
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -26.5,-0.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26907
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-0.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26908
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26909
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,-6.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26910
     components:
     - type: Transform
       pos: -11.5,8.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26911
     components:
     - type: Transform
       pos: -30.5,12.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26912
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,4.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26913
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26914
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -42.5,-0.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26915
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,-5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26916
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,-6.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26917
     components:
     - type: Transform
       pos: 24.5,99.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26918
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,96.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26919
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,96.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26920
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,115.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26921
     components:
     - type: Transform
       pos: 43.5,106.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26922
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -75.5,114.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26923
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-4.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 26924
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -34.5,-21.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: RMCSynthResetKey
   entities:
   - uid: 26925


### PR DESCRIPTION
## Описание PR
На Алмайер в отдел карго добавлена стационарная консоль возврата имущества из криосна (.

## Причина / Баланс
Парити сс13. Вроде бы поставил туда же где и должно было быть

## Технические детали
Размещение консоли

## Медиа
<img width="379" height="329" alt="image" src="https://github.com/user-attachments/assets/fb64dbc4-f43b-487f-b4f8-c83d1fa1bbd3" />

## Требования
- [X] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [X] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
- [X] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.

**Changelog (Список изменений)**
:cl:
- add: В отдел Карго добавлена консоль возврата снаряжения из криосна.