### PR TITLE
Исправление возврата лотка ОБ

### DIFF
--- a/Content.Shared/_RMC14/OrbitalCannon/OrbitalCannonSystem.cs
+++ b/Content.Shared/_RMC14/OrbitalCannon/OrbitalCannonSystem.cs
@@ -684,17 +684,20 @@ public sealed class OrbitalCannonSystem : EntitySystem
 
                 cannon.Comp.Status = OrbitalCannonStatus.Unloaded;
                 cannon.Comp.LastFireAt = time;
+                cannon.Comp.UnloadingTrayAt = time;
                 Dirty(cannon, cannon.Comp);
 
                 var cannonEnt = new Entity<OrbitalCannonComponent>(cannon, cannon.Comp);
-                CannonStatusChanged(cannonEnt);
 
                 if (_container.TryGetContainer(trayId, tray.FuelContainer, out var fuelCont))
                     _container.CleanContainer(fuelCont);
 
                 if (_container.TryGetContainer(trayId, tray.WarheadContainer, out var warheadCont))
                     _container.CleanContainer(warheadCont);
-                
+
+                _animation.TryFlick(cannon.Owner, cannon.Comp.UnloadingAnimation, cannon.Comp.UnloadedState, cannon.Comp.BaseLayerKey);
+                CannonStatusChanged(cannonEnt);
+
                 return false;
             }
 


### PR DESCRIPTION
## Описание PR
Исправлен баг орбитальной пушки: если ОБ блокировалась защитой hive core, загрузочный лоток не возвращался наружу и пушка больше не могла быть перезаряжена.

## Причина / Баланс
Исправление не меняет баланс ОБ: при блокировке защитой hive core боеголовка и топливо всё ещё расходуются, а пушка уходит на кулдаун. Меняется только сломанное состояние, при котором лоток застревал внутри пушки и делал дальнейшую загрузку невозможной.

## Технические детали
В protected-ветке `OrbitalCannonSystem.Fire` теперь выставляется `UnloadingTrayAt`, запускается штатная анимация выгрузки, а обновление состояния вызывается после очистки топлива и боеголовки. Существующий `Update` возвращает лоток из контейнера пушки обратно на позицию загрузки.


## Медиа
Не требуется: PR исправляет внутреннюю логику ОБ и локализацию текста.

## Требования
- [X] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [X] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
- [X] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.

**Changelog (Список изменений)**
- fix: Исправлено застревание загрузочного лотка орбитальной пушки после блокировки ОБ защитой hive core.