### PR TITLE
Исправление отображения погодного оверлея поверх ксенозрения

### DIFF
--- a/Content.Client/_RMC14/Weather/RMCWeatherFullscreenOverlay.cs
+++ b/Content.Client/_RMC14/Weather/RMCWeatherFullscreenOverlay.cs
@@ -60,7 +60,8 @@ public sealed class RMCWeatherFullscreenOverlay : Overlay
         _lookup = lookup;
         _timing = timing;
         _shader = prototypes.Index<ShaderPrototype>("RMCWeatherPersonalOverlay").InstanceUnique();
-        ZIndex = -1;
+        // Draw above night vision and xeno world-info overlays so weather limits their visibility.
+        ZIndex = 3;
     }
 
     protected override bool BeforeDraw(in OverlayDrawArgs args)


### PR DESCRIPTION
## Описание PR

Исправляет порядок отрисовки погодного полноэкранного оверлея RMC. Теперь погодный эффект отображается поверх ночного зрения и xeno world-info overlays, а не скрывается под ними.

## Причина / Баланс

До изменения ксенозрения могло визуально перекрывать погодный оверлей, из-за чего погода не ограничивала видимость так, как должна. Это исправление возвращает ожидаемое влияние погоды на обзор и не меняет численные параметры баланса.

## Технические детали

В `RMCWeatherFullscreenOverlay` изменен `ZIndex` с `-1` на `3`. Это поднимает погодный оверлей выше оверлеев ночного зрения и ксенозрения в порядке отрисовки.

## Медиа

Не требуется.

## Требования
- [x] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [x] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
- [x] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.

**Changelog (Список изменений)**
- fix: Погодный оверлей теперь корректно отображается поверх ксенозрения.