### PR TITLE
Задержка взрывов труб после стана от падения дропшипа

### DIFF
--- a/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
+++ b/Content.Server/_RMC14/Hijack/RMCHijackRandomDamageSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Destructible;
+using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Atmos;
 using Content.Shared._RMC14.Dropship;
 using Content.Shared._RMC14.Explosion;
@@ -8,6 +9,7 @@ using Content.Shared.Explosion;
 using Content.Shared.FixedPoint;
 using Content.Shared.GameTicking;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
@@ -21,6 +23,7 @@ namespace Content.Server._RMC14.Hijack;
 public sealed class RMCHijackRandomDamageSystem : EntitySystem
 {
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly SharedRMCExplosionSystem _rmcExplosion = default!;
     [Dependency] private readonly SharedRMCFlammableSystem _rmcFlammable = default!;
@@ -50,6 +53,8 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
     private const float PipeExplosionMax = 20f;
     private const int PipeFireRange = 2;
 
+    private TimeSpan _hijackCrashStunTime;
+
     private readonly List<(EntityUid Uid, RMCHijackRandomDamageTargetComponent Comp)> _wallTargets = new();
     private readonly List<(EntityUid Uid, RMCHijackRandomDamageTargetComponent Comp)> _windowTargets = new();
     private readonly List<(EntityUid Uid, RMCHijackRandomDamageTargetComponent Comp)> _windoorTargets = new();
@@ -62,6 +67,8 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         SubscribeLocalEvent<RMCHijackActivePipeComponent, ComponentRemove>(OnPipeRemove);
         SubscribeLocalEvent<RMCHijackActivePipeComponent, EntityTerminatingEvent>(OnPipeRemove);
         SubscribeLocalEvent<RMCHijackActivePipeComponent, AnchorStateChangedEvent>(OnPipeAnchorChanged);
+
+        Subs.CVar(_config, RMCCVars.RMCHijackCrashStunTimeSeconds, v => _hijackCrashStunTime = TimeSpan.FromSeconds(v), true);
     }
 
     private void OnRoundRestart(RoundRestartCleanupEvent ev)
@@ -120,7 +127,8 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
         ApplyRandomDamage(_windowTargets, WindowMinPercent, WindowMaxPercent);
         ApplyRandomDamage(_windoorTargets, WindoorMinPercent, WindoorMaxPercent);
 
-        DoPipeBarrage(ev.Map, PipeInitialMinPercent, PipeInitialMaxPercent);
+        map.InitialPipeBarragePending = true;
+        map.Next = _timing.CurTime + _hijackCrashStunTime;
     }
 
     private void OnPipeRemove<T>(Entity<RMCHijackActivePipeComponent> ent, ref T args)
@@ -321,6 +329,13 @@ public sealed class RMCHijackRandomDamageSystem : EntitySystem
 
             if (time < active.Next)
                 continue;
+
+            if (active.InitialPipeBarragePending)
+            {
+                active.InitialPipeBarragePending = false;
+                DoPipeBarrage((uid, active), PipeInitialMinPercent, PipeInitialMaxPercent);
+                continue;
+            }
 
             DoPipeBarrage((uid, active));
         }

--- a/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/DistressSignal/CMDistressSignalRuleSystem.cs
@@ -167,7 +167,7 @@ public sealed partial class CMDistressSignalRuleSystem : GameRuleSystem<CMDistre
     private float _minimumSurvivors;
     private int _mapVoteExcludeLast;
     private bool _useCarryoverVoting;
-    private readonly TimeSpan _hijackStunTime = TimeSpan.FromSeconds(5);
+    private TimeSpan _hijackStunTime;
     private bool _landingZoneMiasmaEnabled;
     private TimeSpan _sunsetDuration;
     private TimeSpan _sunriseDuration;
@@ -285,6 +285,7 @@ public sealed partial class CMDistressSignalRuleSystem : GameRuleSystem<CMDistre
         Subs.CVar(_config, RMCCVars.RMCSunsetDuration, v => _sunsetDuration = TimeSpan.FromSeconds(v), true);
         Subs.CVar(_config, RMCCVars.RMCSunriseDuration, v => _sunriseDuration = TimeSpan.FromSeconds(v), true);
         Subs.CVar(_config, RMCCVars.RMCForceEndHijackTimeMinutes, v => _forceEndHijackTime = TimeSpan.FromMinutes(v), true);
+        Subs.CVar(_config, RMCCVars.RMCHijackCrashStunTimeSeconds, v => _hijackStunTime = TimeSpan.FromSeconds(v), true);
         Subs.CVar(_config, RMCCVars.RMCHijackShipWeight, v => _hijackShipWeight = v, true);
         Subs.CVar(_config, RMCCVars.RMCMinimumHijackBurrowed, v => _hijackMinBurrowed = v, true);
         Subs.CVar(_config, RMCCVars.RMCDistressXenosMinimum, v => _xenosMinimum = v, true);

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -469,6 +469,9 @@ public sealed partial class RMCCVars : CVars
     public static readonly CVarDef<int> RMCForceEndHijackTimeMinutes =
         CVarDef.Create("rmc.force_hijack_end_time_minutes", 25, CVar.REPLICATED | CVar.SERVER);
 
+    public static readonly CVarDef<int> RMCHijackCrashStunTimeSeconds =
+        CVarDef.Create("rmc.hijack_crash_stun_time_seconds", 5, CVar.REPLICATED | CVar.SERVER);
+
     public static readonly CVarDef<float> RMCMovementPenCapSubtract =
         CVarDef.Create("rmc.movement_pen_cap_subtract", 0.8f, CVar.REPLICATED | CVar.SERVER);
 

--- a/Content.Shared/_RMC14/Hijack/RMCHijackActiveMapComponent.cs
+++ b/Content.Shared/_RMC14/Hijack/RMCHijackActiveMapComponent.cs
@@ -16,6 +16,9 @@ public sealed partial class RMCHijackActiveMapComponent : Component
     public TimeSpan NextDelay = TimeSpan.FromSeconds(15);
 
     [DataField]
+    public bool InitialPipeBarragePending;
+
+    [DataField]
     public List<EntityUid> Explode = new();
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]


### PR DESCRIPTION
## About the PR
Задерживает первый залп взрывов труб при хайджеке до момента, когда заканчивается стан от падения хайджекнутого дропшипа на корабль.

## Why / Balance
Сейчас игроки получают стан сразу после падения дропшипа, и в этот же момент начинается цикл взрывов труб. Из-за этого предупреждения и взрывы труб могут начинаться, пока игроки ещё не могут реагировать.

Изменение сохраняет сам удар, стан и структурный урон по кораблю, но даёт игрокам вернуть контроль перед началом pipe barrage.

## Technical details
Добавлен CVar `rmc.hijack_crash_stun_time_seconds`, который используется как единый источник времени для стана от падения хайджекнутого дропшипа.

`CMDistressSignalRuleSystem` теперь использует этот CVar для длительности паралича. `RMCHijackRandomDamageSystem` использует тот же CVar, чтобы отложить первый залп труб вместо немедленного запуска на `DropshipHijackLandedEvent`.

В `RMCHijackActiveMapComponent` добавлен `InitialPipeBarragePending`, чтобы после задержки первый залп всё ещё использовал initial pipe percentages. Следующие залпы продолжают работать через существующий `NextDelay`.

## Media
Не требуется, изменение только в тайминге геймплея.


## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [x] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
<!-- Пояснение к пункту ниже, подтверждая этот пункт, вы не теряете авторские права. Вы всё ещё владеете своим оригинальным кодом/артом и можете использовать его в своих личных целях. Галочка означает лишь то, что вы передаете проекту Space Stories (и его администрации) неэксклюзивное право свободно использовать этот вклад в наших сборках и связанных проектах. -->
- [x] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.
<!-- Имейте в виду, что несоблюдение вышеуказанных требований может привести к закрытию вашего PR на усмотрение мейнтейнеров -->

**Changelog (Список изменений)**
- fix: Взрывы труб при хайджеке теперь начинаются после окончания стана от падения дропшипа.