### PR TITLE
Добавление консоли возврата имущества в Карго

### DIFF
--- a/Resources/Maps/_Stories/almayer.yml
+++ b/Resources/Maps/_Stories/almayer.yml
@@ -200802,4 +200802,12 @@ entities:
     - type: Transform
       pos: -115.5,87.5
       parent: 1
+- proto: RMCCryoRecoveryConsole
+  entities:
+  - uid: 46377
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 33.5,-8.5
+      parent: 1
 ...


### PR DESCRIPTION
<!-- Руководство: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
## Описание PR
На Алмайер в отдел карго добавлена стационарная консоль возврата имущества из криосна (.

## Причина / Баланс
Парити сс13. Вроде бы поставил туда же где и должно было быть

## Технические детали
Размещение консоли

## Медиа
<img width="379" height="329" alt="image" src="https://github.com/user-attachments/assets/fb64dbc4-f43b-487f-b4f8-c83d1fa1bbd3" />

## Требования
- [X] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [X] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
- [X] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.

**Changelog (Список изменений)**
:cl:
- add: В отдел Карго добавлена консоль возврата снаряжения из криосна.