### PR TITLE
Добавление корабельной ПВО IX-50 MGAD на карту

### DIFF
--- a/Resources/Maps/_Stories/almayer.yml
+++ b/Resources/Maps/_Stories/almayer.yml
@@ -182221,17 +182221,13 @@ entities:
     - type: Transform
       pos: -114.5,-8.5
       parent: 1
+- proto: RMCShipAntiAirConsole
+  entities:
   - uid: 25156
     components:
-    - type: MetaData
-      name: системная консоль МГАД
     - type: Transform
       pos: -114.5,4.5
       parent: 1
-    missingComponents:
-    - UserInterface
-    - ActivatableUI
-    - OrbitalCannonComputer
 - proto: RMCOrbitalCannonFuel
   entities:
   - uid: 25157
@@ -187364,7 +187360,7 @@ entities:
     - type: Transform
       pos: -50.5,113.5
       parent: 1
-- proto: RMCRailgunProp
+- proto: RMCShipAntiAirCannon
   entities:
   - uid: 25828
     components:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/anti_air.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/anti_air.yml
@@ -6,6 +6,7 @@
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/computer.rsi
+    drawdepth: HighFloorObjects
     layers:
     - map: ["base"]
       state: "ob_console0"


### PR DESCRIPTION
<!-- Руководство: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
На карту добавлена стационарная корабельная система ПВО IX-50 MGAD  Объект размещен над орбитальной пушкой.

## Причина / Баланс
Парити

## Технические детали
- На карту добавлено пво и консоль
- Настроены слои отрисовки объекта (`drawdepth`), чтобы спрайт консоли отображались корректно.

## Медиа
[<img width="927" height="566" alt="image" src="https://github.com/user-attachments/assets/fc7d34f1-fcc8-4a63-8d85-43e393cf1e0d" />]

## Требования
- [X] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [X] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
- [X] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.
**Changelog (Список изменений)**
:cl:
- add: На карту установлена корабельная система ПВО IX-50 MGAD.