### PR TITLE
Добавил Мусорку в коридоре у карго

### DIFF
--- a/Resources/Maps/_Stories/almayer.yml
+++ b/Resources/Maps/_Stories/almayer.yml
@@ -57129,7 +57129,7 @@ entities:
     - type: Transform
       pos: -33.5,-16.5
       parent: 1
-  - uid: 28027
+  - uid: 28028
     components:
     - type: Transform
       pos: 28.5,-0.5
@@ -118602,7 +118602,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 24.5,93.5
       parent: 1
-  - uid: 28038
+  - uid: 28039
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -127409,47 +127409,47 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 48.5,5.5
       parent: 1
-  - uid: 28029
+  - uid: 28030
     components:
     - type: Transform
       pos: 28.5,0.5
       parent: 1
-  - uid: 28030
+  - uid: 28031
     components:
     - type: Transform
       pos: 28.5,1.5
       parent: 1
-  - uid: 28031
+  - uid: 28032
     components:
     - type: Transform
       pos: 28.5,2.5
       parent: 1
-  - uid: 28032
+  - uid: 28033
     components:
     - type: Transform
       pos: 28.5,3.5
       parent: 1
-  - uid: 28033
+  - uid: 28034
     components:
     - type: Transform
       pos: 28.5,4.5
       parent: 1
-  - uid: 28034
+  - uid: 28035
     components:
     - type: Transform
       pos: 28.5,5.5
       parent: 1
-  - uid: 28035
+  - uid: 28036
     components:
     - type: Transform
       pos: 28.5,6.5
       parent: 1
-  - uid: 28036
+  - uid: 28037
     components:
     - type: Transform
       pos: 28.5,7.5
       parent: 1
-  - uid: 28037
+  - uid: 28038
     components:
     - type: Transform
       pos: 28.5,8.5
@@ -127908,7 +127908,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -33.5,-16.5
       parent: 1
-  - uid: 28028
+  - uid: 28029
     components:
     - type: Transform
       rot: 3.141592653589793 rad

--- a/Resources/Maps/_Stories/almayer.yml
+++ b/Resources/Maps/_Stories/almayer.yml
@@ -118602,7 +118602,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 24.5,93.5
       parent: 1
-  - uid: 28039
+  - uid: 28044
     components:
     - type: Transform
       rot: 3.141592653589793 rad

--- a/Resources/Maps/_Stories/almayer.yml
+++ b/Resources/Maps/_Stories/almayer.yml
@@ -57129,6 +57129,11 @@ entities:
     - type: Transform
       pos: -33.5,-16.5
       parent: 1
+  - uid: 28027
+    components:
+    - type: Transform
+      pos: 28.5,-0.5
+      parent: 1
 - proto: CMDoublCMDoubleDoorPreparationsDeltaLocked
   entities:
   - uid: 4997
@@ -117777,12 +117782,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 24.5,9.5
       parent: 1
-  - uid: 16141
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 28.5,9.5
-      parent: 1
   - uid: 16142
     components:
     - type: Transform
@@ -118602,6 +118601,12 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,93.5
+      parent: 1
+  - uid: 28038
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 28.5,9.5
       parent: 1
 - proto: DisposalPipe
   entities:
@@ -127404,6 +127409,51 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 48.5,5.5
       parent: 1
+  - uid: 28029
+    components:
+    - type: Transform
+      pos: 28.5,0.5
+      parent: 1
+  - uid: 28030
+    components:
+    - type: Transform
+      pos: 28.5,1.5
+      parent: 1
+  - uid: 28031
+    components:
+    - type: Transform
+      pos: 28.5,2.5
+      parent: 1
+  - uid: 28032
+    components:
+    - type: Transform
+      pos: 28.5,3.5
+      parent: 1
+  - uid: 28033
+    components:
+    - type: Transform
+      pos: 28.5,4.5
+      parent: 1
+  - uid: 28034
+    components:
+    - type: Transform
+      pos: 28.5,5.5
+      parent: 1
+  - uid: 28035
+    components:
+    - type: Transform
+      pos: 28.5,6.5
+      parent: 1
+  - uid: 28036
+    components:
+    - type: Transform
+      pos: 28.5,7.5
+      parent: 1
+  - uid: 28037
+    components:
+    - type: Transform
+      pos: 28.5,8.5
+      parent: 1
 - proto: DisposalTrunk
   entities:
   - uid: 17801
@@ -127857,6 +127907,12 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,-16.5
+      parent: 1
+  - uid: 28028
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 28.5,-0.5
       parent: 1
 - proto: DisposalYJunction
   entities:


### PR DESCRIPTION
<!-- Руководство: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
В коридоре около отдела поставок была поставлен мусорка

## Причина / Баланс
Морпехи постоянно заваливают коридор у карго пустыми коробками, пайками и прочим хламом, создавая хаос и мешая проходу. Добавление мусорки в этой зоне даст морпехам возможность быстро избавиться от мусора а не захламлять коридор.

## Технические детали
- На карту добавлена мусорка и трубопровод

## Медиа
[<img width="365" height="819" alt="image" src="https://github.com/user-attachments/assets/f2b72ac4-f91b-40f5-bd56-5be04a94e92a" />]

## Требования
- [X] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [X] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
- [X] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.
**Changelog (Список изменений)**
:cl:
- add: В коридоре возле отдела снабжения установлен мусорный бак для поддержания чистоты.