### PR TITLE
Возвращение мензурки на 300

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Lathe/medilathe.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Lathe/medilathe.yml
@@ -141,7 +141,7 @@
   - RMCMedicAutoInjector30
   - CMHypospray
   - CMBloodPack
-  # - RMCBeakerHighCapacity replaced in RMC by RMCReagentJug
+  - RMCBeakerHighCapacity
   - RMCReagentJug
   - CMBonesetter
   #    - FixOVein (5000 Plastic)->(6250)


### PR DESCRIPTION
<!-- Руководство: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
В медицинский фабрикатор вернулся рецепт создания большой мензурки объемом 300 унций.

## Причина / Баланс
Изменение внесено в соответствии с одобренным предложением.  https://discord.com/channels/1175915376559792189/1513468647262130266

## Технические детали
- В рецепты медицинского фабрикатора добавлен соответствующий рецепт.

## Медиа
[<img width="736" height="501" alt="image" src="https://github.com/user-attachments/assets/4ab6aedc-b390-4d22-bbca-1081884c531e" />]

## Требования
- [X] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [X] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
- [X] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.

**Changelog (Список изменений)**
:cl:
- add: В медицинский фабрикатор добавлен рецепт крафта мензурки на 300 унций.