### PR TITLE
Смена стеклянной двери в общем брифруме с ВП на Командование.

### DIFF
--- a/Resources/Maps/_Stories/almayer.yml
+++ b/Resources/Maps/_Stories/almayer.yml
@@ -110863,6 +110863,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 6.5,-0.5
       parent: 1
+    - type: AccessReader
+      access:
+      - - RMCAccessCommand
   - uid: 14863
     components:
     - type: Transform

--- a/Resources/Maps/_Stories/almayer.yml
+++ b/Resources/Maps/_Stories/almayer.yml
@@ -110855,7 +110855,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 26.5,96.5
       parent: 1
-- proto: CMWindoorSecureBrig
+- proto: CMWindoorSecureCommand
   entities:
   - uid: 14862
     components:
@@ -110863,9 +110863,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 6.5,-0.5
       parent: 1
-    - type: AccessReader
-      access:
-      - - RMCAccessCommand
+- proto: CMWindoorSecureBrig
+  entities:
   - uid: 14863
     components:
     - type: Transform


### PR DESCRIPTION
<!-- Руководство: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Заменена защищенная стеклянная дверь в общем брифруме. Доступы Военной полиции изменены на доступы Командования.

## Причина / Баланс
Не думаю что доступ в комнатке для командования нужен доступ ВП вместо доступа командования.

## Технические детали
Был удален объект в данном месте CMWindoorSecureBrig и добавлен CMWindoorSecureCommand

## Медиа
<img width="353" height="250" alt="image" src="https://github.com/user-attachments/assets/0ba19c2c-4146-4196-bd1e-d051b11e37ed" />

## Требования
- [X] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [X] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
- [X] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.

**Changelog (Список изменений)**
:cl:
- tweak: Изменен доступ к защищенной стеклянной двери шлюза: теперь требуется доступ Командования вместо Военной полиции.