### PR TITLE
Добавление печати ВНа в шкаф.

### DIFF
--- a/Resources/Maps/_Stories/almayer.yml
+++ b/Resources/Maps/_Stories/almayer.yml
@@ -69595,6 +69595,15 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 105.84878,82.428246
       parent: 1
+- proto: CMStampMW
+  entities:
+  - uid: 28141
+    components:
+    - type: Transform
+      parent: 18540
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: CMTableAlmayer
   entities:
   - uid: 7165
@@ -132330,6 +132339,7 @@ entities:
           occludes: True
           ents:
           - 18541
+          - 28141
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True


### PR DESCRIPTION
<!-- Руководство: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
В шкаф военного надзирателя была добавлена его персональная печать.

## Причина / Баланс
Ранее у военного надзирателя отсутствовала собственная печать, что усложняло процесс заверения официальных бумаг, протоколов допроса и других документов военной без обращения к Начальнику Военной полиции. Добавление печати логично дополняет его работу.

## Технические детали
Добавлена печать в шкаф в его коморке

## Требования
- [X] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [X] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
- [X] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](/LICENSE.txt) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.

**Changelog (Список изменений)**
:cl:
- add: Добавлена печать военного надзирателя в его шкаф.