### PR TITLE
Исправления погоды 

### DIFF
--- a/Resources/Maps/_RMC14/chances.yml
+++ b/Resources/Maps/_RMC14/chances.yml
@@ -144,16 +144,23 @@ entities:
       data: {}
     - type: RMCWeatherCycle
       minTimeBetweenEvents: 1800
+      warnTime: 60
+      minTimeBetweenChecks: 0
+      minCheckVariance: 0
+      startChance: 1
       weatherEvents:
-      - duration: 180
-        weatherType: RMCStrataStormLight
-        lightningChance: 0.04
+      - lightningSound: !type:SoundCollectionSpecifier
+          collection: RMCThunder
         lightningEffects:
         - RMCColorSequenceLightningSharpPeak
         - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
-          collection: RMCThunder
-        name: Heavy Rain
+        lightningChance: 0.04
+        fireSmotheringStrength: 2
+        weatherType: RMCStrataStormVeryLight
+        screenOverlay: Low
+        duration: 180
+        name: Light Rain
+        displayName: rmc-weather-name-light-rain
     - type: RMCAmbientLightEffects
       sunset: RMCColorSequenceSunsetCold
     - type: Broadphase

--- a/Resources/Maps/_RMC14/hybrisa.yml
+++ b/Resources/Maps/_RMC14/hybrisa.yml
@@ -14007,26 +14007,36 @@ entities:
             10991: -202.89621,-44.960754
     - type: RadiationGridResistance
     - type: RMCWeatherCycle
-      minTimeBetweenEvents: 900
+      minTimeBetweenEvents: 720
+      warnTime: 60
+      minTimeBetweenChecks: 0
+      minCheckVariance: 0
+      startChance: 1
       weatherEvents:
-      - duration: 900
-        weatherType: RMCHybrisaRainLight
+      - lightningSound: !type:SoundCollectionSpecifier
+          collection: RMCThunder
+        lightningEffects:
+        - RMCColorSequenceLightningSharpPeak
+        - RMCColorSequenceLightningFlicker
         lightningChance: 0.04
-        lightningEffects:
-        - RMCColorSequenceLightningSharpPeak
-        - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
-          collection: RMCThunder
+        fireSmotheringStrength: 1
+        weatherType: RMCHybrisaRainLight
+        screenOverlay: Low
+        duration: 900
         name: Hybrisa Light Rain
-      - duration: 900
-        weatherType: RMCHybrisaRainVeryLight
-        lightningChance: 0.02
+        displayName: rmc-weather-name-light-rain
+      - lightningSound: !type:SoundCollectionSpecifier
+          collection: RMCThunder
         lightningEffects:
         - RMCColorSequenceLightningSharpPeak
         - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
-          collection: RMCThunder
+        lightningChance: 0.02
+        fireSmotheringStrength: 0
+        weatherType: RMCHybrisaRainVeryLight
+        screenOverlay: Low
+        duration: 900
         name: Hybrisa Very Light Rain
+        displayName: rmc-weather-name-very-light-rain
     - type: AreaGrid
       labels: {}
       areaEntities: {}

--- a/Resources/Maps/_RMC14/kutjevo.yml
+++ b/Resources/Maps/_RMC14/kutjevo.yml
@@ -170,24 +170,35 @@ entities:
       data: {}
     - type: RMCWeatherCycle
       minTimeBetweenEvents: 1200
+      minTimeBetweenChecks: 0
+      minCheckVariance: 0
+      startChance: 1
       weatherEvents:
-      - duration: 360
-        weatherType: RMCBigRedSand
+      - lightningSound: !type:SoundCollectionSpecifier
+          collection: RMCThunder
         lightningEffects:
         - RMCColorSequenceLightningSharpPeak
         - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
+        fireSmotheringStrength: 2
+        cleansDecals: false
+        effectMessage: rmc-weather-effect-sand
+        weatherType: RMCSolarisSand
+        screenOverlay: Medium
+        duration: 360
+        name: Sandstorm
+        displayName: rmc-weather-name-sandstorm
+      - lightningSound: !type:SoundCollectionSpecifier
           collection: RMCThunder
-        name: Duststorm
-      - duration: 240
-        weatherType: RMCStrataStormLight
+        lightningEffects:
+        - RMCColorSequenceLightningSharpPeak
+        - RMCColorSequenceLightningFlicker
         lightningChance: 0.02
-        lightningEffects:
-        - RMCColorSequenceLightningSharpPeak
-        - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
-          collection: RMCThunder
+        fireSmotheringStrength: 4
+        weatherType: RMCStrataStormLight
+        screenOverlay: Medium
+        duration: 240
         name: Rainstorm
+        displayName: rmc-weather-name-rainstorm
     - type: RMCAmbientLightEffects
     - type: Broadphase
     - type: OccluderTree

--- a/Resources/Maps/_RMC14/lv624.yml
+++ b/Resources/Maps/_RMC14/lv624.yml
@@ -187,24 +187,33 @@ entities:
       data: {}
     - type: RMCWeatherCycle
       minTimeBetweenEvents: 1200
+      minTimeBetweenChecks: 900
+      minCheckVariance: 600
+      startChance: 0.3
       weatherEvents:
-      - duration: 480
+      - lightningSound: !type:SoundCollectionSpecifier
+          collection: RMCThunder
+        lightningEffects:
+        - RMCColorSequenceLightningSharpPeak
+        - RMCColorSequenceLightningFlicker
+        fireSmotheringStrength: 1
         weatherType: RMCStrataStormVeryLight
-        lightningEffects:
-        - RMCColorSequenceLightningSharpPeak
-        - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
-          collection: RMCThunder
+        screenOverlay: Low
+        duration: 480
         name: Light Rain
-      - duration: 720
-        weatherType: RMCStrataStormLight
-        lightningChance: 0.02
+        displayName: rmc-weather-name-light-rain
+      - lightningSound: !type:SoundCollectionSpecifier
+          collection: RMCThunder
         lightningEffects:
         - RMCColorSequenceLightningSharpPeak
         - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
-          collection: RMCThunder
+        lightningChance: 0.02
+        fireSmotheringStrength: 4
+        weatherType: RMCStrataStormLight
+        screenOverlay: Medium
+        duration: 720
         name: Heavy Rain
+        displayName: rmc-weather-name-heavy-rain
     - type: RMCAmbientLightEffects
     - type: MapGrid
       chunks:

--- a/Resources/Maps/_RMC14/shiva.yml
+++ b/Resources/Maps/_RMC14/shiva.yml
@@ -132,31 +132,34 @@ entities:
       data: {}
     - type: RMCWeatherCycle
       minTimeBetweenEvents: 1200
+      minTimeBetweenChecks: 0
+      minCheckVariance: 0
+      startChance: 1
       weatherEvents:
-      - duration: 600
+      - lightningSound: !type:SoundCollectionSpecifier
+          collection: RMCThunder
+        lightningEffects:
+        - RMCColorSequenceLightningSharpPeak
+        - RMCColorSequenceLightningFlicker
+        fireSmotheringStrength: 0
+        cleansDecals: false
         weatherType: RMCStrataClearsky
-        lightningEffects:
-        - RMCColorSequenceLightningSharpPeak
-        - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
-          collection: RMCThunder
+        screenOverlay: Low
+        duration: 600
         name: Snow
-      - duration: 360
+        displayName: rmc-weather-name-snow
+      - lightningSound: !type:SoundCollectionSpecifier
+          collection: RMCThunder
+        lightningEffects:
+        - RMCColorSequenceLightningSharpPeak
+        - RMCColorSequenceLightningFlicker
+        fireSmotheringStrength: 1
+        cleansDecals: false
         weatherType: RMCStrataSnowing
-        lightningEffects:
-        - RMCColorSequenceLightningSharpPeak
-        - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
-          collection: RMCThunder
+        screenOverlay: Medium
+        duration: 360
         name: Snowstorm
-      - duration: 240
-        weatherType: RMCStrataBlizzard
-        lightningEffects:
-        - RMCColorSequenceLightningSharpPeak
-        - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
-          collection: RMCThunder
-        name: Blizzard
+        displayName: rmc-weather-name-snowstorm
     - type: RMCAmbientLightEffects
       sunset: RMCColorSequenceSunsetCold
     - type: MapGrid

--- a/Resources/Maps/_RMC14/solaris.yml
+++ b/Resources/Maps/_RMC14/solaris.yml
@@ -289,23 +289,36 @@ entities:
       data: {}
     - type: RMCWeatherCycle
       minTimeBetweenEvents: 1200
+      minTimeBetweenChecks: 900
+      minCheckVariance: 600
+      startChance: 0.3
       weatherEvents:
-      - duration: 600
-        weatherType: RMCBigRedDust
+      - lightningSound: !type:SoundCollectionSpecifier
+          collection: RMCThunder
         lightningEffects:
         - RMCColorSequenceLightningSharpPeak
         - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
-          collection: RMCThunder
+        fireSmotheringStrength: 1
+        cleansDecals: false
+        effectMessage: rmc-weather-effect-dust
+        weatherType: RMCSolarisDust
+        screenOverlay: Low
+        duration: 600
         name: Duststorm
-      - duration: 360
-        weatherType: RMCBigRedSand
+        displayName: rmc-weather-name-duststorm
+      - lightningSound: !type:SoundCollectionSpecifier
+          collection: RMCThunder
         lightningEffects:
         - RMCColorSequenceLightningSharpPeak
         - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
-          collection: RMCThunder
+        fireSmotheringStrength: 2
+        cleansDecals: false
+        effectMessage: rmc-weather-effect-sand
+        weatherType: RMCSolarisSand
+        screenOverlay: Medium
+        duration: 360
         name: Sandstorm
+        displayName: rmc-weather-name-sandstorm
     - type: RMCAmbientLightEffects
     - type: MapGrid
       chunks:

--- a/Resources/Maps/_RMC14/sorokyne.yml
+++ b/Resources/Maps/_RMC14/sorokyne.yml
@@ -3141,34 +3141,49 @@ entities:
     - type: MapLight
     - type: RMCWeatherCycle
       minTimeBetweenEvents: 1800
+      minTimeBetweenChecks: 900
+      minCheckVariance: 600
+      startChance: 1
       weatherEvents:
-      - duration: 180
-        weatherType: RMCStrataStormVeryLight
-        lightningChance: 0.04
+      - lightningSound: !type:SoundCollectionSpecifier
+          collection: RMCThunder
         lightningEffects:
         - RMCColorSequenceLightningSharpPeak
         - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
-          collection: RMCThunder
-        name: Light Rain
-      - duration: 180
-        weatherType: RMCStrataStormVeryLight
         lightningChance: 0.01
-        lightningEffects:
-        - RMCColorSequenceLightningSharpPeak
-        - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
-          collection: RMCThunder
+        fireSmotheringStrength: 1
+        weatherType: RMCStrataStormTropical
+        screenOverlay: Low
+        duration: 180
         name: Tropical Storm
-      - duration: 240
-        weatherType: RMCStrataStormLight
-        lightningChance: 0.06
+        displayName: rmc-weather-name-tropical-storm
+      - lightningSound: !type:SoundCollectionSpecifier
+          collection: RMCThunder
         lightningEffects:
         - RMCColorSequenceLightningSharpPeak
         - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
-          collection: RMCThunder
+        lightningChance: 0.06
+        fireSmotheringStrength: 4
+        warningMode: SirenOnly
+        warningSirenKind: Weather
+        warningSound: !type:SoundPathSpecifier
+          path: /Audio/_RMC14/Effects/weather_warning.wav
+        weatherType: RMCStrataStormVaradero
+        screenOverlay: High
+        duration: 240
         name: Monsoon
+        displayName: rmc-weather-name-monsoon-warning
+      - lightningSound: !type:SoundCollectionSpecifier
+          collection: RMCThunder
+        lightningEffects:
+        - RMCColorSequenceLightningSharpPeak
+        - RMCColorSequenceLightningFlicker
+        lightningChance: 0.04
+        fireSmotheringStrength: 1
+        weatherType: RMCStrataStormVeryLightRainAndThunder
+        duration: 180
+        name: Soro Light Rain
+        displayName: rmc-weather-name-light-rain
     - type: RMCAmbientLightEffects
     - type: BecomesStation
       id: Sorokyne

--- a/Resources/Maps/_RMC14/trijent.yml
+++ b/Resources/Maps/_RMC14/trijent.yml
@@ -465,24 +465,35 @@ entities:
       data: {}
     - type: RMCWeatherCycle
       minTimeBetweenEvents: 1200
+      minTimeBetweenChecks: 0
+      minCheckVariance: 0
+      startChance: 1
       weatherEvents:
-      - duration: 360
-        weatherType: RMCBigRedDust
+      - lightningSound: !type:SoundCollectionSpecifier
+          collection: RMCThunder
         lightningEffects:
         - RMCColorSequenceLightningSharpPeak
         - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
-          collection: RMCThunder
+        fireSmotheringStrength: 1
+        cleansDecals: false
+        effectMessage: rmc-weather-effect-dust
+        weatherType: RMCSolarisDust
+        screenOverlay: Low
+        duration: 360
         name: Duststorm
-      - duration: 360
-        weatherType: RMCTrijentRainLight
-        lightningChance: 0.01
+        displayName: rmc-weather-name-duststorm
+      - lightningSound: !type:SoundCollectionSpecifier
+          collection: RMCThunder
         lightningEffects:
         - RMCColorSequenceLightningSharpPeak
         - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
-          collection: RMCThunder
+        lightningChance: 0.01
+        fireSmotheringStrength: 4
+        weatherType: RMCTrijentRainLight
+        screenOverlay: Medium
+        duration: 360
         name: Rainstorm
+        displayName: rmc-weather-name-rainstorm
     - type: RMCAmbientLightEffects
     - type: BecomesStation
       id: Trijent

--- a/Resources/Maps/_RMC14/varadero.yml
+++ b/Resources/Maps/_RMC14/varadero.yml
@@ -150,25 +150,42 @@ entities:
       data: {}
     - type: RMCWeatherCycle
       minTimeBetweenEvents: 900
+      minTimeBetweenChecks: 900
+      minCheckVariance: 600
+      startChance: 1
       weatherEvents:
-      - duration: 240
-        weatherType: RMCStrataStormVeryLight
+      - lightningSound: !type:SoundCollectionSpecifier
+          collection: RMCThunder
+        lightningEffects:
+        - RMCColorSequenceLightningSharpPeak
+        - RMCColorSequenceLightningFlicker
         lightningChance: 0.01
-        lightningEffects:
-        - RMCColorSequenceLightningSharpPeak
-        - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
-          collection: RMCThunder
+        fireSmotheringStrength: 1
+        warningMode: SirenOnly
+        warningSirenKind: Storm
+        warningSound: !type:SoundPathSpecifier
+          path: /Audio/_RMC14/Effects/weather_warning_varadero.wav
+        weatherType: RMCStrataStormTropical
+        screenOverlay: Low
+        duration: 240
         name: Tropical Storm
-      - duration: 360
-        weatherType: RMCStrataStormLight
-        lightningChance: 0.06
+        displayName: rmc-weather-name-tropical-storm
+      - lightningSound: !type:SoundCollectionSpecifier
+          collection: RMCThunder
         lightningEffects:
         - RMCColorSequenceLightningSharpPeak
         - RMCColorSequenceLightningFlicker
-        lightningSound: !type:SoundCollectionSpecifier
-          collection: RMCThunder
+        lightningChance: 0.06
+        fireSmotheringStrength: 4
+        warningMode: SirenOnly
+        warningSirenKind: Storm
+        warningSound: !type:SoundPathSpecifier
+          path: /Audio/_RMC14/Effects/weather_warning_varadero.wav
+        weatherType: RMCStrataStormVaradero
+        screenOverlay: High
+        duration: 360
         name: Monsoon
+        displayName: rmc-weather-name-monsoon-warning
     - type: RMCAmbientLightEffects
     - type: MapGrid
       chunks:


### PR DESCRIPTION
## Описание PR

Восстановлены настройки погодных событий на обычных картах.

## Причина / Баланс

Дождь, снег и бури отображались визуально, но не ограничивали обзор и частично не применяли игровые эффекты.

## Технические детали

Возвращены `screenOverlay`, сила тушения огня, локализованные названия, тайминги и map-specific настройки для 9 карт.

## Медиа

Не требуется: исправление конфигов.

**Changelog (Список изменений)**

:cl:GrigoriyGalintano
- fix: Исправлены эффекты и ограничение обзора у погодных событий на картах.