### PR TITLE
Исправление семантических хоткеев морпехов и ксеносов

### DIFF
--- a/Content.Client/_RMC14/Input/RMCActionKeybindSystem.cs
+++ b/Content.Client/_RMC14/Input/RMCActionKeybindSystem.cs
@@ -24,99 +24,99 @@ public sealed class RMCActionKeybindSystem : EntitySystem
 
         CommandBinds.Builder
             .Bind(CMKeyFunctions.RMCMarineIssueOrder,
-                InputCmdHandler.FromDelegate(session => OpenOrderMenu(session?.AttachedEntity), handle: false))
+                InputCmdHandler.FromDelegate(session => OpenOrderMenu(session?.AttachedEntity), handle: true))
             .Bind(CMKeyFunctions.RMCMarineIssueOrderFocus,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.MarineOrderFocus),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCMarineIssueOrderHold,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.MarineOrderHold),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCMarineIssueOrderMove,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.MarineOrderMove),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCMarineSpecialistOne,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.MarineSpecialistOne),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCMarineSpecialistTwo,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.MarineSpecialistTwo),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCMarineCycleHelmetHud,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.MarineCycleHelmetHud),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCToggleIff,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.MarineToggleIff),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCXenoPrimaryActionOne,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.XenoPrimaryOne),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCXenoPrimaryActionTwo,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.XenoPrimaryTwo),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCXenoPrimaryActionThree,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.XenoPrimaryThree),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCXenoPrimaryActionFour,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.XenoPrimaryFour),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCXenoPrimaryActionFive,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.XenoPrimaryFive),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCXenoCorrosiveAcid,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.XenoCorrosiveAcid),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCXenoEvolve,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.XenoEvolve),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCXenoHide,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.XenoHide),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCXenoPheromones,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.XenoPheromones),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCXenoPheromonesFrenzy,
                 InputCmdHandler.FromDelegate(
                     _ => RaiseNetworkEvent(new XenoPheromonesKeybindEvent(XenoPheromones.Frenzy)),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCXenoPheromonesRecovery,
                 InputCmdHandler.FromDelegate(
                     _ => RaiseNetworkEvent(new XenoPheromonesKeybindEvent(XenoPheromones.Recovery)),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCXenoPheromonesWarding,
                 InputCmdHandler.FromDelegate(
                     _ => RaiseNetworkEvent(new XenoPheromonesKeybindEvent(XenoPheromones.Warding)),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCXenoPurchaseStrain,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.XenoEvolve),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCXenoScreech,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.XenoScreech),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCXenoTailStab,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.XenoTailStab),
-                    handle: false))
+                    handle: true))
             .Bind(CMKeyFunctions.RMCXenoWordQueen,
                 InputCmdHandler.FromDelegate(
                     session => TryTrigger(session?.AttachedEntity, RMCKeybindActionSlot.XenoWordQueen),
-                    handle: false))
+                    handle: true))
             .Register<RMCActionKeybindSystem>();
     }
 

--- a/Content.Client/_RMC14/UserInterface/Systems/Actions/ActionUIController.Keybinds.cs
+++ b/Content.Client/_RMC14/UserInterface/Systems/Actions/ActionUIController.Keybinds.cs
@@ -5,23 +5,28 @@ namespace Content.Client.UserInterface.Systems.Actions;
 public sealed partial class ActionUIController
 {
     /// <summary>
-    /// Triggers an owned action through the same validation and targeting path as the action UI.
+    /// Routes an owned action through the same targeting and activation paths as the action UI.
     /// </summary>
     public bool TryTriggerRMCAction(EntityUid actionId)
     {
         if (_actionsSystem?.GetAction(actionId) is not { } action ||
             _playerManager.LocalEntity is not { } user ||
             action.Comp.AttachedEntity != user ||
-            !_actionsSystem.ValidAction(action))
+            !action.Comp.Enabled)
         {
             return false;
         }
 
         if (EntityManager.TryGetComponent<TargetActionComponent>(actionId, out var target))
+        {
             ToggleTargeting((actionId, action.Comp, target));
-        else
-            _actionsSystem.TriggerAction(action);
+            return true;
+        }
 
+        if (!EntityManager.HasComponent<InstantActionComponent>(actionId))
+            return false;
+
+        _actionsSystem.TriggerAction(action);
         return true;
     }
 }


### PR DESCRIPTION
## Описание PR

Исправлена обработка семантических хоткеев морпехов и ксеносов.

## Причина / Баланс

Хоткеи могли конфликтовать с другими действиями или некорректно запускать способности. На баланс не влияет.

## Технические детали

- Нажатия хоткеев теперь помечаются обработанными.
- Исправлен запуск мгновенных и требующих выбора цели способностей.

## Медиа

Не требуется.

## Требования

- [x] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [x] Я подтверждаю авторство или наличие необходимых лицензий.
- [x] Я ознакомился(ась) с [Space Stories License Agreement](https://github.com/MetalSage/space-stories-cm14/blob/master/LICENSE.TXT) и согласен(на) с его условиями.

**Changelog (Список изменений)**

:cl:GrigoriyGalintano
- fix: Исправлена работа семантических хоткеев морпехов и ксеносов.