### PR TITLE
Смена отряда для камер Overwatch на треногах

### DIFF
--- a/Content.Server/_RMC14/Overwatch/OverwatchConsoleSystem.cs
+++ b/Content.Server/_RMC14/Overwatch/OverwatchConsoleSystem.cs
@@ -22,6 +22,7 @@ public sealed class OverwatchConsoleSystem : SharedOverwatchConsoleSystem
 
         SubscribeLocalEvent<OverwatchCameraComponent, ComponentRemove>(OnWatchedRemove);
         SubscribeLocalEvent<OverwatchCameraComponent, EntityTerminatingEvent>(OnWatchedRemove);
+        SubscribeLocalEvent<OverwatchCameraComponent, RMCOverwatchTripodSquadChangedEvent>(OnWatchedSquadChanged);
         SubscribeLocalEvent<OverwatchWatchingComponent, ComponentRemove>(OnWatchingRemove);
         SubscribeLocalEvent<OverwatchWatchingComponent, EntityTerminatingEvent>(OnWatchingRemove);
     }
@@ -65,15 +66,41 @@ public sealed class OverwatchConsoleSystem : SharedOverwatchConsoleSystem
 
     private void OnWatchedRemove<T>(Entity<OverwatchCameraComponent> ent, ref T args)
     {
+        RemoveWatchers(ent);
+    }
+
+    private void OnWatchedSquadChanged(
+        Entity<OverwatchCameraComponent> ent,
+        ref RMCOverwatchTripodSquadChangedEvent args)
+    {
+        RemoveWatchers(ent);
+        ent.Comp.Watching.Clear();
+        Dirty(ent);
+    }
+
+    private void RemoveWatchers(Entity<OverwatchCameraComponent> ent)
+    {
         foreach (var watching in new List<EntityUid>(ent.Comp.Watching))
         {
             if (TerminatingOrDeleted(watching))
                 continue;
 
             if (TryComp(watching, out ActorComponent? actor) && actor != null)
-                Unwatch(watching, actor.PlayerSession);
+            {
+                if (TryComp(watching, out EyeComponent? eye))
+                {
+                    Unwatch((watching, eye), actor.PlayerSession);
+                }
+                else
+                {
+                    _viewSubscriber.RemoveViewSubscriber(ent, actor.PlayerSession);
+                    RemCompDeferred<OverwatchWatchingComponent>(watching);
+                }
+            }
             else
+            {
                 RemCompDeferred<OverwatchWatchingComponent>(watching);
+            }
         }
     }
 

--- a/Content.Shared/_RMC14/Overwatch/RMCOverwatchTripodCameraComponent.cs
+++ b/Content.Shared/_RMC14/Overwatch/RMCOverwatchTripodCameraComponent.cs
@@ -1,5 +1,8 @@
+using Content.Shared._RMC14.Marines.Squads;
+using Content.Shared._RMC14.Weapons.Ranged.IFF;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._RMC14.Overwatch;
@@ -16,6 +19,15 @@ public sealed partial class RMCOverwatchTripodCameraComponent : Component
 
     [DataField, AutoNetworkedField]
     public EntityUid? Squad;
+
+    [DataField(required: true)]
+    public EntProtoId<SquadTeamComponent> DefaultSquad;
+
+    [DataField(required: true)]
+    public string SelectableSquadGroup = string.Empty;
+
+    [DataField(required: true)]
+    public EntProtoId<IFFFactionComponent> AssignmentFaction;
 
     [DataField, AutoNetworkedField]
     public bool Deployed;

--- a/Content.Shared/_RMC14/Overwatch/RMCOverwatchTripodCameraEvents.cs
+++ b/Content.Shared/_RMC14/Overwatch/RMCOverwatchTripodCameraEvents.cs
@@ -17,3 +17,9 @@ public record struct RMCOverwatchTripodDeployAttemptEvent(EntityUid User, bool C
 [Serializable, NetSerializable]
 public sealed record RMCOverwatchTripodRenameInputEvent(NetEntity Camera, NetEntity User, string Message = "")
     : DialogInputEvent(Message);
+
+[Serializable, NetSerializable]
+public sealed record RMCOverwatchTripodSetSquadEvent(NetEntity Camera, NetEntity User, NetEntity Squad);
+
+[ByRefEvent]
+public readonly record struct RMCOverwatchTripodSquadChangedEvent;

--- a/Content.Shared/_RMC14/Overwatch/SharedRMCOverwatchTripodCameraSystem.cs
+++ b/Content.Shared/_RMC14/Overwatch/SharedRMCOverwatchTripodCameraSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared._RMC14.Explosion;
 using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.Marines.Squads;
 using Content.Shared._RMC14.Vehicle;
+using Content.Shared._RMC14.Weapons.Ranged.IFF;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared.ActionBlocker;
 using Content.Shared.DoAfter;
@@ -19,6 +20,8 @@ using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
 using Robust.Shared.Utility;
 
 namespace Content.Shared._RMC14.Overwatch;
@@ -33,10 +36,13 @@ public abstract class SharedRMCOverwatchTripodCameraSystem : EntitySystem
     [Dependency] private readonly DialogSystem _dialog = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly GunIFFSystem _iff = default!;
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly RMCMapSystem _map = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SquadSystem _squad = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public override void Initialize()
@@ -50,6 +56,7 @@ public abstract class SharedRMCOverwatchTripodCameraSystem : EntitySystem
         SubscribeLocalEvent<RMCOverwatchTripodCameraComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<RMCOverwatchTripodCameraComponent, AttackedEvent>(OnAttacked);
         SubscribeLocalEvent<RMCOverwatchTripodCameraComponent, CombatModeShouldHandInteractEvent>(OnCombatModeShouldHandInteract);
+        SubscribeLocalEvent<ActorComponent, RMCOverwatchTripodSetSquadEvent>(OnSetSquad);
     }
 
     private void OnUseInHand(Entity<RMCOverwatchTripodCameraComponent> ent, ref UseInHandEvent args)
@@ -84,6 +91,15 @@ public abstract class SharedRMCOverwatchTripodCameraSystem : EntitySystem
 
         if (ent.Comp.Deployed)
         {
+            if (CanChangeSquad(ent, user))
+            {
+                args.Verbs.Add(new ActivationVerb
+                {
+                    Text = Loc.GetString("rmc-overwatch-tripod-camera-change-squad"),
+                    Act = () => OpenSquadSelection(ent, user),
+                });
+            }
+
             args.Verbs.Add(new ActivationVerb
             {
                 Text = Loc.GetString("rmc-overwatch-tripod-camera-pick-up"),
@@ -104,6 +120,84 @@ public abstract class SharedRMCOverwatchTripodCameraSystem : EntitySystem
     {
         var ev = new RMCOverwatchTripodRenameInputEvent(GetNetEntity(ent), GetNetEntity(user));
         _dialog.OpenInput(user, Loc.GetString("rmc-overwatch-tripod-camera-rename-prompt"), ev, characterLimit: 32);
+    }
+
+    private void OpenSquadSelection(Entity<RMCOverwatchTripodCameraComponent> ent, EntityUid user)
+    {
+        if (_net.IsClient || !CanChangeSquad(ent, user, true))
+            return;
+
+        var squads = new List<(EntityUid Id, string Name)>();
+        var query = EntityQueryEnumerator<SquadTeamComponent>();
+        while (query.MoveNext(out var squadId, out var squad))
+        {
+            if (squadId == ent.Comp.Squad ||
+                !string.Equals(squad.Group, ent.Comp.SelectableSquadGroup, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            squads.Add((squadId, Name(squadId)));
+        }
+
+        squads.Sort(static (left, right) => string.CompareOrdinal(left.Name, right.Name));
+        if (squads.Count == 0)
+        {
+            _popup.PopupEntity(
+                Loc.GetString(
+                    "rmc-overwatch-tripod-camera-squad-change-no-options",
+                    ("group", ent.Comp.SelectableSquadGroup)),
+                ent,
+                user,
+                PopupType.SmallCaution);
+            return;
+        }
+
+        var options = new List<DialogOption>(squads.Count);
+        foreach (var squad in squads)
+        {
+            options.Add(new DialogOption(
+                squad.Name,
+                new RMCOverwatchTripodSetSquadEvent(
+                    GetNetEntity(ent),
+                    GetNetEntity(user),
+                    GetNetEntity(squad.Id))));
+        }
+
+        _dialog.OpenOptions(
+            user,
+            Loc.GetString("rmc-overwatch-tripod-camera-squad-selection-title"),
+            options,
+            Loc.GetString("rmc-overwatch-tripod-camera-squad-selection-prompt"));
+    }
+
+    private void OnSetSquad(Entity<ActorComponent> actor, ref RMCOverwatchTripodSetSquadEvent args)
+    {
+        if (_net.IsClient ||
+            !TryGetEntity(args.User, out var user) ||
+            user.Value != actor.Owner ||
+            !TryGetEntity(args.Camera, out var camera) ||
+            !TryComp(camera, out RMCOverwatchTripodCameraComponent? tripod) ||
+            TerminatingOrDeleted(camera.Value) ||
+            !CanChangeSquad((camera.Value, tripod), user.Value, true) ||
+            !TryGetEntity(args.Squad, out var squad) ||
+            TerminatingOrDeleted(squad.Value) ||
+            !TryComp(squad, out SquadTeamComponent? team) ||
+            !string.Equals(team.Group, tripod.SelectableSquadGroup, StringComparison.Ordinal) ||
+            tripod.Squad == squad.Value)
+        {
+            return;
+        }
+
+        tripod.Squad = squad.Value;
+        Dirty(camera.Value, tripod);
+
+        var changed = new RMCOverwatchTripodSquadChangedEvent();
+        RaiseLocalEvent(camera.Value, ref changed);
+        _popup.PopupEntity(
+            Loc.GetString("rmc-overwatch-tripod-camera-squad-changed", ("squad", Name(squad.Value))),
+            camera.Value,
+            user.Value);
     }
 
     private void TryStartDeploy(Entity<RMCOverwatchTripodCameraComponent> ent, EntityUid user)
@@ -128,7 +222,7 @@ public abstract class SharedRMCOverwatchTripodCameraSystem : EntitySystem
     {
         if (args.Cancelled ||
             args.Handled ||
-            !CanDeploy(ent, args.User, out var coordinates, out var rotation) ||
+            !CanDeploy(ent, args.User, out var coordinates, out var rotation, out var squad) ||
             !_hands.TryDrop(args.User, ent, coordinates))
         {
             return;
@@ -139,7 +233,7 @@ public abstract class SharedRMCOverwatchTripodCameraSystem : EntitySystem
         _transform.AnchorEntity(ent);
         ent.Comp.Deployed = true;
         ent.Comp.XenoSlashes = 0;
-        ent.Comp.Squad = CompOrNull<SquadMemberComponent>(args.User)?.Squad;
+        ent.Comp.Squad = squad;
         EnsureComp<OverwatchCameraComponent>(ent);
         _appearance.SetData(ent, RMCOverwatchTripodCameraVisuals.Deployed, true);
         _audio.PlayPredicted(ent.Comp.DeploySound, ent, args.User);
@@ -285,18 +379,20 @@ public abstract class SharedRMCOverwatchTripodCameraSystem : EntitySystem
 
     private bool CanDeploy(Entity<RMCOverwatchTripodCameraComponent> ent, EntityUid user)
     {
-        return CanDeploy(ent, user, out _, out _);
+        return CanDeploy(ent, user, out _, out _, out _);
     }
 
     private bool CanDeploy(
         Entity<RMCOverwatchTripodCameraComponent> ent,
         EntityUid user,
         out EntityCoordinates coordinates,
-        out Angle rotation)
+        out Angle rotation,
+        out EntityUid squad)
     {
         var moverCoordinates = _transform.GetMoverCoordinateRotation(user, Transform(user));
         coordinates = _map.SnapToGrid(moverCoordinates.Coords);
         rotation = moverCoordinates.worldRot.GetCardinalDir().ToAngle();
+        squad = default;
 
         if (ent.Comp.Deployed ||
             !_mobState.IsAlive(user) ||
@@ -326,8 +422,73 @@ public abstract class SharedRMCOverwatchTripodCameraSystem : EntitySystem
             return false;
         }
 
+        if (_net.IsServer && !TryGetDeploymentSquad(ent, user, out squad))
+        {
+            _popup.PopupClient(
+                Loc.GetString("rmc-overwatch-tripod-camera-default-squad-unavailable"),
+                ent,
+                user,
+                PopupType.SmallCaution);
+            return false;
+        }
+
         var attempt = new RMCOverwatchTripodDeployAttemptEvent(user);
         RaiseLocalEvent(ent.Owner, ref attempt);
         return !attempt.Cancelled;
+    }
+
+    /// <summary>
+    /// Resolves the squad assigned when the tripod finishes deploying.
+    /// </summary>
+    public bool TryGetDeploymentSquad(
+        Entity<RMCOverwatchTripodCameraComponent> ent,
+        EntityUid user,
+        out EntityUid squad)
+    {
+        if (_squad.TryGetMemberSquad(user, out var memberSquad) &&
+            !TerminatingOrDeleted(memberSquad))
+        {
+            squad = memberSquad;
+            return true;
+        }
+
+        if (_squad.TryGetSquad(ent.Comp.DefaultSquad, out var defaultSquad) &&
+            !TerminatingOrDeleted(defaultSquad))
+        {
+            squad = defaultSquad;
+            return true;
+        }
+
+        squad = default;
+        return false;
+    }
+
+    private bool CanChangeSquad(
+        Entity<RMCOverwatchTripodCameraComponent> ent,
+        EntityUid user,
+        bool showPopup = false)
+    {
+        if (!ent.Comp.Deployed ||
+            !_mobState.IsAlive(user) ||
+            _mobState.IsIncapacitated(user) ||
+            !_actionBlocker.CanInteract(user, ent) ||
+            !_interaction.InRangeUnobstructed(user, ent.Owner))
+        {
+            return false;
+        }
+
+        if (_iff.IsInFaction(user, ent.Comp.AssignmentFaction))
+            return true;
+
+        if (showPopup)
+        {
+            _popup.PopupClient(
+                Loc.GetString("rmc-overwatch-tripod-camera-squad-change-iff-denied"),
+                ent,
+                user,
+                PopupType.SmallCaution);
+        }
+
+        return false;
     }
 }

--- a/Resources/Locale/en-US/_RMC14/overwatch.ftl
+++ b/Resources/Locale/en-US/_RMC14/overwatch.ftl
@@ -52,6 +52,13 @@ rmc-overwatch-tripod-camera-collapsed = The field camera tripod collapses.
 rmc-overwatch-tripod-camera-destroyed = The field camera tripod is destroyed.
 rmc-overwatch-tripod-camera-examine-label = The label reads: [color=cyan]{ $label }[/color].
 rmc-overwatch-tripod-camera-examine-squad = It is currently assigned to squad: [color=cyan]{ $squad }[/color].
+rmc-overwatch-tripod-camera-change-squad = Change squad
+rmc-overwatch-tripod-camera-squad-selection-title = Camera Squad Assignment
+rmc-overwatch-tripod-camera-squad-selection-prompt = Select the squad to assign this camera to.
+rmc-overwatch-tripod-camera-squad-changed = Camera assigned to { $squad } squad.
+rmc-overwatch-tripod-camera-squad-change-iff-denied = Your IFF does not permit you to reassign this camera.
+rmc-overwatch-tripod-camera-squad-change-no-options = There are no other active { $group } squads available.
+rmc-overwatch-tripod-camera-default-squad-unavailable = No default squad is available for the field camera tripod.
 rmc-overwatch-console-state-unconscious = Unconscious
 rmc-overwatch-console-state-dead = Dead
 rmc-overwatch-console-state-conscious = Conscious

--- a/Resources/Locale/ru-RU/_RMC14/overwatch.ftl
+++ b/Resources/Locale/ru-RU/_RMC14/overwatch.ftl
@@ -52,6 +52,13 @@ rmc-overwatch-tripod-camera-collapsed = Тренога с полевой кам�
 rmc-overwatch-tripod-camera-destroyed = Тренога с полевой камерой уничтожена.
 rmc-overwatch-tripod-camera-examine-label = На табличке написано: [color=cyan]{ $label }[/color].
 rmc-overwatch-tripod-camera-examine-squad = Сейчас камера закреплена за отрядом: [color=cyan]{ $squad }[/color].
+rmc-overwatch-tripod-camera-change-squad = Сменить отряд
+rmc-overwatch-tripod-camera-squad-selection-title = Назначение камеры отряду
+rmc-overwatch-tripod-camera-squad-selection-prompt = Выберите отряд, за которым будет закреплена эта камера.
+rmc-overwatch-tripod-camera-squad-changed = Камера закреплена за отрядом { $squad }.
+rmc-overwatch-tripod-camera-squad-change-iff-denied = Ваша система IFF не позволяет переназначить эту камеру.
+rmc-overwatch-tripod-camera-squad-change-no-options = Других активных отрядов группы { $group } нет.
+rmc-overwatch-tripod-camera-default-squad-unavailable = Для полевой камеры на треноге нет доступного отряда по умолчанию.
 rmc-overwatch-console-state-unconscious = Без сознания
 rmc-overwatch-console-state-dead = Мёртв
 rmc-overwatch-console-state-conscious = В сознании

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/overwatch_tripod_camera.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/overwatch_tripod_camera.yml
@@ -24,6 +24,9 @@
   - type: Damageable
     damageContainer: Inorganic
   - type: RMCOverwatchTripodCamera
+    defaultSquad: SquadAlpha
+    selectableSquadGroup: UNMC
+    assignmentFaction: FactionMarine
     deploySound:
       path: /Audio/_RMC14/Items/mine_armed.ogg
       params:


### PR DESCRIPTION
## Описание PR

Добавлена возможность переназначать установленную камеру Overwatch на другой активный отряд.

## Причина / Баланс

Позволяет использовать камеру для другого отряда без её демонтажа. Переназначение доступно только персонажам с подходящим IFF.

## Технические детали

- Добавлен диалог выбора активного отряда UNMC.
- При смене отряда завершается текущее наблюдение через камеру.
- Для установки без принадлежности к отряду используется отряд «Альфа».

## Медиа

не надо

## Требования

- [x] Я прочитал(а) и следую руководству по Pull Request и Changelog.
- [x] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [x] Я подтверждаю авторство кода и ассетов либо наличие необходимых лицензий.
- [x] Я ознакомился(ась) и согласен(на) с Space Stories License Agreement.

**Changelog (Список изменений)**

:cl:GrigoriyGalintano
- tweak: Камеры Overwatch на треногах теперь можно переназначать другим отрядам.