### PR TITLE
Языковая поддержка в диктофоне

### DIFF
--- a/Content.Server/Speech/EntitySystems/ListeningSystem.cs
+++ b/Content.Server/Speech/EntitySystems/ListeningSystem.cs
@@ -1,7 +1,9 @@
 using Content.Server.Chat.Systems;
 using Content.Server.Speech.Components;
+using Content.Shared._RMC14.Language.Prototypes; // RMC14
 using Content.Shared._RMC14.Mentor.ImaginaryFriend;
 using Content.Shared._RMC14.Xenonids;
+using Robust.Shared.Prototypes; // RMC14
 
 namespace Content.Server.Speech.EntitySystems;
 
@@ -20,10 +22,14 @@ public sealed class ListeningSystem : EntitySystem
 
     private void OnSpeak(EntitySpokeEvent ev)
     {
-        PingListeners(ev.Source, ev.Message, ev.ObfuscatedMessage);
+        PingListeners(ev.Source, ev.Message, ev.ObfuscatedMessage, ev.Language); // RMC14
     }
 
-    public void PingListeners(EntityUid source, string message, string? obfuscatedMessage)
+    public void PingListeners(
+        EntityUid source,
+        string message,
+        string? obfuscatedMessage,
+        ProtoId<LanguagePrototype>? language = null) // RMC14
     {
         // RMC14
         if (HasComp<XenoComponent>(source) || HasComp<ImaginaryFriendComponent>(source))
@@ -38,11 +44,11 @@ public sealed class ListeningSystem : EntitySystem
         var sourcePos = _xforms.GetWorldPosition(sourceXform, xformQuery);
 
         var attemptEv = new ListenAttemptEvent(source);
-        var ev = new ListenEvent(message, source);
-        var obfuscatedEv = obfuscatedMessage == null ? null : new ListenEvent(obfuscatedMessage, source);
+        var ev = new ListenEvent(message, source, language); // RMC14
+        var obfuscatedEv = obfuscatedMessage == null ? null : new ListenEvent(obfuscatedMessage, source, language); // RMC14
         var query = EntityQueryEnumerator<ActiveListenerComponent, TransformComponent>();
 
-        while(query.MoveNext(out var listenerUid, out var listener, out var xform))
+        while (query.MoveNext(out var listenerUid, out var listener, out var xform))
         {
             if (xform.MapID != sourceXform.MapID)
                 continue;

--- a/Content.Server/Speech/ListenEvent.cs
+++ b/Content.Server/Speech/ListenEvent.cs
@@ -1,14 +1,20 @@
+using Content.Shared._RMC14.Language.Prototypes; // RMC14
+using Content.Shared._RMC14.Language.Systems; // RMC14
+using Robust.Shared.Prototypes; // RMC14
+
 namespace Content.Server.Speech;
 
 public sealed class ListenEvent : EntityEventArgs
 {
     public readonly string Message;
     public readonly EntityUid Source;
+    public readonly ProtoId<LanguagePrototype> Language; // RMC14
 
-    public ListenEvent(string message, EntityUid source)
+    public ListenEvent(string message, EntityUid source, ProtoId<LanguagePrototype>? language = null) // RMC14
     {
         Message = message;
         Source = source;
+        Language = language ?? SharedLanguageSystem.CommonLanguage; // RMC14
     }
 }
 

--- a/Content.Server/_RMC14/Chat/Chat/ChatSystem.Language.cs
+++ b/Content.Server/_RMC14/Chat/Chat/ChatSystem.Language.cs
@@ -442,7 +442,7 @@ public sealed partial class ChatSystem
             ("originalName", originalSpeakerName));
     }
 
-    private void SendInVoiceRangeWithLanguage(
+    public void SendInVoiceRangeWithLanguage(
         ChatChannel channel,
         string speakerMessage,
         string wrappedMessageTemplate,
@@ -454,9 +454,10 @@ public sealed partial class ChatSystem
         bool visibleLanguage = false,
         NetUserId? author = null,
         string? transformedName = null,
-        bool needsLos = false)
+        bool needsLos = false,
+        bool ignoreXenos = false)
     {
-        foreach (var (session, data) in GetRecipients(source, VoiceRange))
+        foreach (var (session, data) in GetRecipients(source, VoiceRange, ignoreXenos))
         {
             var entRange = MessageRangeCheck(session, data, range);
             if (entRange == MessageRangeCheckResult.Disallowed)

--- a/Content.Server/_RMC14/UniversalRecorder/UniversalRecorderSystem.cs
+++ b/Content.Server/_RMC14/UniversalRecorder/UniversalRecorderSystem.cs
@@ -1,9 +1,11 @@
 using System.Text;
+using Content.Server._RMC14.Language.Systems;
 using Content.Server.Atmos;
-using Content.Server.Chat.Managers;
 using Content.Server.Chat.Systems;
 using Content.Server.Speech;
 using Content.Server.Speech.Components;
+using Content.Shared._RMC14.Language.Prototypes;
+using Content.Shared._RMC14.Language.Systems;
 using Content.Shared._RMC14.UniversalRecorder;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared.Atmos;
@@ -25,7 +27,6 @@ using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
-using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
@@ -42,11 +43,11 @@ public sealed class UniversalRecorderSystem : EntitySystem
 
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
-    [Dependency] private readonly IChatManager _chatManager = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly SharedItemSystem _item = default!;
     [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
+    [Dependency] private readonly LanguageSystem _language = default!;
     [Dependency] private readonly MetaDataSystem _metaData = default!;
     [Dependency] private readonly PaperSystem _paper = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -169,7 +170,7 @@ public sealed class UniversalRecorderSystem : EntitySystem
 
             var usedPercent = ent.Comp.MaxCapacity == TimeSpan.Zero
                 ? 0
-                : (int) MathF.Floor((float) (tapeRuntime.UsedCapacity.TotalSeconds / ent.Comp.MaxCapacity.TotalSeconds * 100f));
+                : (int)MathF.Floor((float)(tapeRuntime.UsedCapacity.TotalSeconds / ent.Comp.MaxCapacity.TotalSeconds * 100f));
 
             var key = usedPercent switch
             {
@@ -491,7 +492,7 @@ public sealed class UniversalRecorderSystem : EntitySystem
         args.Handled = _tool.UseTool(args.Used,
             args.User,
             ent.Owner,
-            (float) ent.Comp.RespoolTime.TotalSeconds,
+            (float)ent.Comp.RespoolTime.TotalSeconds,
             ent.Comp.ScrewdriverQuality,
             new UniversalRecorderTapeRespoolDoAfterEvent());
     }
@@ -512,6 +513,10 @@ public sealed class UniversalRecorderSystem : EntitySystem
     {
         var runtime = GetRecorderRuntime(ent);
         if (runtime.State != UniversalRecorderState.Recording)
+            return;
+
+        var (language, languagePrototype) = ResolveLanguage(args.Language);
+        if (!languagePrototype.NeedsSpeech)
             return;
 
         if (!TryGetTape(ent, out var tape))
@@ -550,7 +555,8 @@ public sealed class UniversalRecorderSystem : EntitySystem
             args.Message,
             speech.FontId,
             speech.FontSize,
-            speech.Bold));
+            speech.Bold,
+            language));
         tapeRuntime.UsedCapacity = currentDuration;
     }
 
@@ -767,7 +773,7 @@ public sealed class UniversalRecorderSystem : EntitySystem
             runtime.WarningSent = true;
             SendRecorderNotice(ent,
                 Loc.GetString("rmc-universal-recorder-popup-warning",
-                    ("seconds", Math.Max(0, (int) remaining.TotalSeconds))));
+                    ("seconds", Math.Max(0, (int)remaining.TotalSeconds))));
         }
 
         if (used < tape.Comp.MaxCapacity)
@@ -830,7 +836,7 @@ public sealed class UniversalRecorderSystem : EntitySystem
         var delta = nextEntry.Timestamp - currentEntry.Timestamp;
         if (delta > ent.Comp1.PlaybackSilenceThreshold)
         {
-            runtime.PendingSilenceSeconds = Math.Max(1, (int) Math.Round(delta.TotalSeconds));
+            runtime.PendingSilenceSeconds = Math.Max(1, (int)Math.Round(delta.TotalSeconds));
             runtime.NextPlaybackAt = _timing.CurTime + TimeSpan.FromSeconds(1);
             return;
         }
@@ -884,7 +890,19 @@ public sealed class UniversalRecorderSystem : EntitySystem
             if (text.Length >= paperComp.ContentSize)
                 break;
 
-            var line = FormatTranscriptLine(entry.Timestamp, entry.SpeakerName, entry.SpeechVerb, entry.Text);
+            var (language, languagePrototype) = ResolveLanguage(entry.Language);
+            var entryText = _language.ObfuscateMessageForListener(user, entry.Text, language);
+            var languageIndicator = languagePrototype.ShowLanguageName
+                ? Loc.GetString(
+                    "rmc-universal-recorder-transcript-language",
+                    ("language", languagePrototype.LocalizedName))
+                : null;
+            var line = FormatTranscriptLine(
+                entry.Timestamp,
+                entry.SpeakerName,
+                entry.SpeechVerb,
+                entryText,
+                languageIndicator);
             AppendLineLimited(text, FormattedMessage.EscapeText(line), paperComp.ContentSize);
         }
 
@@ -980,26 +998,32 @@ public sealed class UniversalRecorderSystem : EntitySystem
 
     private void SendPlaybackSpeech(Entity<UniversalRecorderComponent> ent, RecorderEntry entry)
     {
-        var wrapped = Loc.GetString(
+        var (language, languagePrototype) = ResolveLanguage(entry.Language);
+        var languageIcon = languagePrototype.DisplayedLanguageIcon;
+        var languageIndicator = languagePrototype.ShowLanguageName && string.IsNullOrEmpty(languageIcon)
+            ? $" ({languagePrototype.LocalizedName})"
+            : string.Empty;
+        var fontId = languagePrototype.TypefaceId ?? entry.FontId;
+        var fontSize = languagePrototype.TextSize ?? entry.FontSize;
+        var wrappedMessageTemplate = Loc.GetString(
             entry.Bold ? "chat-manager-entity-say-bold-wrap-message" : "chat-manager-entity-say-wrap-message",
-            ("entityName", FormattedMessage.EscapeText(entry.SpeakerName)),
+            ("entityName", "{1}" + languageIndicator),
             ("verb", entry.SpeechVerb),
-            ("fontType", entry.FontId),
-            ("fontSize", entry.FontSize),
-            ("message", FormattedMessage.EscapeText(entry.Text)));
+            ("fontType", fontId),
+            ("fontSize", fontSize),
+            ("message", "{0}"));
 
-        var filter = Filter.Pvs(ent.Owner, entityManager: EntityManager);
-        filter.RemoveWhereAttachedEntity(HasComp<XenoComponent>);
-
-        _chatManager.ChatMessageToManyFiltered(
-            filter,
+        _chat.SendInVoiceRangeWithLanguage(
             ChatChannel.Local,
             entry.Text,
-            wrapped,
+            wrappedMessageTemplate,
             ent.Owner,
-            hideChat: true,
-            recordReplay: true,
-            colorOverride: null);
+            ChatTransmitRange.HideChat,
+            language,
+            languageIcon,
+            speakerName: FormattedMessage.EscapeText(entry.SpeakerName),
+            transformedName: entry.SpeakerName,
+            ignoreXenos: true);
     }
 
     private TimeSpan GetCurrentRecordedDuration(
@@ -1108,13 +1132,29 @@ public sealed class UniversalRecorderSystem : EntitySystem
 
     private static string FormatTimestamp(TimeSpan timestamp)
     {
-        var totalMinutes = (int) timestamp.TotalMinutes;
+        var totalMinutes = (int)timestamp.TotalMinutes;
         return $"[{totalMinutes:00}:{timestamp.Seconds:00}]";
     }
 
-    private static string FormatTranscriptLine(TimeSpan timestamp, string speakerName, string speechVerb, string text)
+    private static string FormatTranscriptLine(
+        TimeSpan timestamp,
+        string speakerName,
+        string speechVerb,
+        string text,
+        string? languageIndicator)
     {
-        return $"{FormatTimestamp(timestamp)} {speakerName} {speechVerb}, \"{text}\"";
+        return $"{FormatTimestamp(timestamp)} {speakerName} {speechVerb}{languageIndicator}, \"{text}\"";
+    }
+
+    private (ProtoId<LanguagePrototype> Id, LanguagePrototype Prototype) ResolveLanguage(
+        ProtoId<LanguagePrototype>? language)
+    {
+        var languageId = language ?? SharedLanguageSystem.CommonLanguage;
+        if (_prototype.TryIndex(languageId, out LanguagePrototype? languagePrototype))
+            return (languageId, languagePrototype);
+
+        languageId = SharedLanguageSystem.CommonLanguage;
+        return (languageId, _prototype.Index<LanguagePrototype>(languageId));
     }
 
     private static void AppendLineLimited(StringBuilder builder, string line, int maxLength)
@@ -1135,7 +1175,7 @@ public sealed class UniversalRecorderSystem : EntitySystem
 
     private static string FormatDuration(TimeSpan duration)
     {
-        var totalMinutes = (int) duration.TotalMinutes;
+        var totalMinutes = (int)duration.TotalMinutes;
         return $"{totalMinutes}m {duration.Seconds}s";
     }
 }

--- a/Content.Shared/_RMC14/UniversalRecorder/RecorderEntry.cs
+++ b/Content.Shared/_RMC14/UniversalRecorder/RecorderEntry.cs
@@ -1,3 +1,6 @@
+using Content.Shared._RMC14.Language.Prototypes;
+using Robust.Shared.Prototypes;
+
 namespace Content.Shared._RMC14.UniversalRecorder;
 
 public readonly record struct RecorderEntry(
@@ -7,5 +10,6 @@ public readonly record struct RecorderEntry(
     string Text,
     string FontId,
     int FontSize,
-    bool Bold
+    bool Bold,
+    ProtoId<LanguagePrototype>? Language = null
 );

--- a/Resources/Locale/en-US/_RMC14/rmc-universal-recorder.ftl
+++ b/Resources/Locale/en-US/_RMC14/rmc-universal-recorder.ftl
@@ -41,6 +41,7 @@ rmc-universal-recorder-playback-silence = Skipping {$seconds} seconds of silence
 
 rmc-universal-recorder-transcript-header = Transcript:
 rmc-universal-recorder-transcript-name = {$tape} transcript
+rmc-universal-recorder-transcript-language = ({$language})
 
 rmc-universal-recorder-tape-side = It is currently on the [color=lightblue]{$side}[/color].
 rmc-universal-recorder-tape-side-front = front side

--- a/Resources/Locale/ru-RU/_RMC14/rmc-universal-recorder.ftl
+++ b/Resources/Locale/ru-RU/_RMC14/rmc-universal-recorder.ftl
@@ -41,6 +41,7 @@ rmc-universal-recorder-playback-silence = Пропуск тишины: { $second
 
 rmc-universal-recorder-transcript-header = Расшифровка:
 rmc-universal-recorder-transcript-name = Расшифровка { $tape }
+rmc-universal-recorder-transcript-language = ({ $language })
 
 rmc-universal-recorder-tape-side = Сейчас используется [color=lightblue]{ $side }[/color].
 rmc-universal-recorder-tape-side-front = лицевая сторона


### PR DESCRIPTION
## Описание PR

Универсальные рекордеры теперь сохраняют язык каждого записанного сообщения.

При воспроизведении знание языка проверяется отдельно для каждого слушателя. Распечатанная расшифровка учитывает знание языков персонажем, запустившим печать. Неречевые языки, например язык жестов, не записываются.

## Причина / Баланс

Ранее универсальные рекордеры сохраняли только обычный текст без информации о языке. Благодаря этому воспроизведение записи и распечатанные расшифровки позволяли обходить языковые ограничения.

Теперь работа рекордеров соответствует обычной речи. Существующие ограничения для ксенонидов не изменены.

## Технические детали

- В `ListenEvent` добавлена информация о языке, которая передаётся как для обычной, так и для приглушённой речи.
- В записи рекордера добавлено необязательное поле языка. Для отсутствующих или некорректных данных используется общий язык.
- Неречевые языки не записываются.
- Обфускация и форматирование речи при воспроизведении выполняются отдельно для каждого слушателя.
- Расшифровки формируются с учётом знания языков персонажем, запустившим печать, и содержат название языка там, где это необходимо.
- Воспроизведение не вызывает `EntitySpokeEvent`, предотвращая повторную запись и изучение языков.
- Метод отправки языковой речи в голосовом диапазоне сделан публичным и получил необязательную фильтрацию ксенонидов.
- Добавлена английская и русская локализация обозначения языка в расшифровках.

## Медиа

Не требуется: изменение не добавляет новых визуальных элементов.

## Требования

- [X] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [X] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
- [X] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](https://github.com/MetalSage/space-stories-cm14/blob/master/LICENSE.TXT) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.

**Changelog (Список изменений)**

:cl:GrigoriyGalintano
- fix: Воспроизведение и расшифровки универсального рекордера теперь учитывают язык речи.