### PR TITLE
Исправление считывания ID-карт в руках

### DIFF
--- a/Content.Shared/Access/Components/AccessComponent.cs
+++ b/Content.Shared/Access/Components/AccessComponent.cs
@@ -29,6 +29,13 @@ public sealed partial class AccessComponent : Component
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]
     public string? Slot = "id";
+
+    /// <summary>
+    /// Whether this access provider can grant access while held in a hand.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [AutoNetworkedField]
+    public bool AllowInHands = true;
     // Stories-Hunter-End
 
     /// <summary>

--- a/Content.Shared/Access/Systems/SharedAccessSystem.cs
+++ b/Content.Shared/Access/Systems/SharedAccessSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Access.Components;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Inventory;
 using Content.Shared.Roles;
 using Robust.Shared.Containers;
@@ -11,8 +12,8 @@ namespace Content.Shared.Access.Systems
     public abstract class SharedAccessSystem : EntitySystem
     {
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
-        [Dependency] private readonly InventorySystem _inventorySystem = default!; // Stories-Hunter
         [Dependency] private readonly SharedContainerSystem _containerSystem = default!; // Stories-Hunter
+        [Dependency] private readonly SharedHandsSystem _handsSystem = default!; // Stories-Hunter
 
         public override void Initialize()
         {
@@ -44,12 +45,12 @@ namespace Content.Shared.Access.Systems
             if (component.Slot != null &&
                 _containerSystem.TryGetContainingContainer(uid, out var container) &&
                 container is ContainerSlot slotContainer &&
-                HasComp<InventoryComponent>(container.Owner))
+                HasComp<InventoryComponent>(container.Owner) &&
+                slotContainer.ID != component.Slot)
             {
-                if (slotContainer.ID != component.Slot)
-                {
+                var isHeld = _handsSystem.TryGetHand(container.Owner, slotContainer.ID, out _);
+                if (!component.AllowInHands || !isHeld)
                     return;
-                }
             }
             // Stories-Hunter-End
 

--- a/Resources/Prototypes/_Stories/Entities/Clothing/Hands/bracer.yml
+++ b/Resources/Prototypes/_Stories/Entities/Clothing/Hands/bracer.yml
@@ -11,6 +11,7 @@
     sprite: _Stories/Objects/Clothing/Hands/Bracer/base.rsi
   - type: Access
     slot: gloves
+    allowInHands: false
   - type: IdCard
     nameLocId: cm-access-id-card-component-owner-name-job-title-text
     fullNameLocId: cm-access-id-card-component-owner-full-name-job-title-text


### PR DESCRIPTION
## Описание PR

Исправлено считывание ID-карт, находящихся в руках игрока.

Карты командования теперь корректно принимаются картридерами авторизации и могут использоваться для установки красного кода.

## Причина / Баланс

После добавления привязки источников доступа к слотам для Stories-Hunter руки ошибочно начали считаться обычными слотами экипировки. Из-за этого карта после перемещения из слота `id` в руку теряла все доступы.

Изменение восстанавливает ожидаемое поведение ID-карт:

- карта работает в слоте `id` и в руке;
- карта не предоставляет доступ из карманов и других неподходящих слотов;
- список должностей с доступом к красному коду не изменён;
- требования двух картридеров и двухсекундное окно не изменены;
- наруч Hunter по-прежнему предоставляет доступ только в слоте `gloves`.

## Технические детали

- В `AccessComponent` добавлено сетевое поле `AllowInHands`, по умолчанию включённое.
- `SharedAccessSystem` теперь отличает контейнер руки от слотов экипировки через `SharedHandsSystem.TryGetHand`.
- Для `STBracerHunter` установлено `allowInHands: false`, чтобы сохранить ограничения Stories-Hunter.
- Удалена неиспользуемая зависимость `InventorySystem`.

## Медиа

Не требуется: исправление внутренней логики считывания доступов без визуальных изменений.

## Требования

- [x] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [x] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
- [x] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](https://github.com/MetalSage/space-stories-cm14/blob/master/LICENSE.TXT) и полностью согласен(на) с его условиями.

**Changelog (Список изменений)**

- fix: Исправлено считывание ID-карт в руках, в том числе при установке красного кода через картридеры и проходе через двери.