### PR TITLE
TTS для телефонов 

### DIFF
--- a/Content.Server/_RMC14/Telephone/RMCTelephoneSystem.cs
+++ b/Content.Server/_RMC14/Telephone/RMCTelephoneSystem.cs
@@ -23,8 +23,8 @@ namespace Content.Server._RMC14.Telephone;
 
 public sealed class RMCTelephoneSystem : SharedRMCTelephoneSystem
 {
-    [Dependency] private readonly IAdminManager _adminManager = default!;// Stories
-    // [Dependency] private readonly AudioSystem _audio = default!;
+    [Dependency] private readonly IAdminManager _adminManager = default!;
+    // [Dependency] private readonly AudioSystem _audio = default!; // Stories
     [Dependency] private readonly IChatManager _chatManager = default!;
     [Dependency] private readonly CommunicationsTowerSystem _communicationsTower = default!;
     [Dependency] private readonly HandsSystem _hands = default!;

--- a/Content.Server/_RMC14/Telephone/RMCTelephoneSystem.cs
+++ b/Content.Server/_RMC14/Telephone/RMCTelephoneSystem.cs
@@ -5,15 +5,17 @@ using Content.Server.Hands.Systems;
 using Content.Server.Radio;
 using Content.Server.Speech;
 using Content.Server.Speech.Components;
+using Content.Server._Stories.TTS; // Stories
 using Content.Shared._RMC14.Communications;
 using Content.Shared._RMC14.Hands;
 using Content.Shared._RMC14.Radio;
 using Content.Shared._RMC14.Rules;
 using Content.Shared._RMC14.Telephone;
 using Content.Shared._RMC14.Xenonids;
+using Content.Shared._Stories.TTS; // Stories
 using Content.Shared.Chat;
 using Content.Shared.Coordinates;
-using Robust.Server.Audio;
+// using Robust.Server.Audio; // Stories
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
 
@@ -22,13 +24,14 @@ namespace Content.Server._RMC14.Telephone;
 public sealed class RMCTelephoneSystem : SharedRMCTelephoneSystem
 {
     [Dependency] private readonly IAdminManager _adminManager = default!;
-    [Dependency] private readonly AudioSystem _audio = default!;
+    // [Dependency] private readonly AudioSystem _audio = default!; // Stories-TTS: Phone chatter disabled in favor of relayed TTS.
     [Dependency] private readonly IChatManager _chatManager = default!;
     [Dependency] private readonly CommunicationsTowerSystem _communicationsTower = default!;
     [Dependency] private readonly HandsSystem _hands = default!;
     [Dependency] private readonly RMCHandsSystem _rmcHands = default!;
     [Dependency] private readonly RMCPlanetSystem _rmcPlanet = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly TTSSystem _tts = default!; // Stories
 
     public override void Initialize()
     {
@@ -133,9 +136,32 @@ public sealed class RMCTelephoneSystem : SharedRMCTelephoneSystem
             return;
         }
 
+        var ttsMessage = message; // Stories
         var name = GetPhoneName(rotary);
         message = $"{name} says, \"{FormattedMessage.EscapeText(message)}\"";
-        var sound = _audio.GetSound(ent.Comp.SpeakSound);
-        _chatManager.ChatMessageToOne(ChatChannel.Local, message, message, otherPhone, false, actor.PlayerSession.Channel, Color.FromHex("#9956D3"), true, sound, -12, hidePopup: true);
+
+        // Stories-Start
+        // var sound = _audio.GetSound(ent.Comp.SpeakSound);
+        // _chatManager.ChatMessageToOne(ChatChannel.Local, message, message, otherPhone, false, actor.PlayerSession.Channel, Color.FromHex("#9956D3"), true, sound, -12, hidePopup: true);
+
+        _chatManager.ChatMessageToOne(
+            ChatChannel.Local,
+            message,
+            message,
+            otherPhone,
+            false,
+            actor.PlayerSession.Channel,
+            colorOverride: Color.FromHex("#9956D3"),
+            recordReplay: true,
+            hidePopup: true);
+
+        _ = _tts.PlayRelayedTTS(
+            source,
+            ttsMessage,
+            Filter.SinglePlayer(actor.PlayerSession),
+            otherPhone,
+            TTSAudioEffect.StandardRadio,
+            isRadio: true);
+        // Stories-End
     }
 }

--- a/Content.Server/_RMC14/Telephone/RMCTelephoneSystem.cs
+++ b/Content.Server/_RMC14/Telephone/RMCTelephoneSystem.cs
@@ -23,8 +23,8 @@ namespace Content.Server._RMC14.Telephone;
 
 public sealed class RMCTelephoneSystem : SharedRMCTelephoneSystem
 {
-    [Dependency] private readonly IAdminManager _adminManager = default!;
-    // [Dependency] private readonly AudioSystem _audio = default!; // Stories-TTS: Phone chatter disabled in favor of relayed TTS.
+    [Dependency] private readonly IAdminManager _adminManager = default!;// Stories
+    // [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly IChatManager _chatManager = default!;
     [Dependency] private readonly CommunicationsTowerSystem _communicationsTower = default!;
     [Dependency] private readonly HandsSystem _hands = default!;

--- a/Content.Server/_Stories/TTS/TTSSystem.Relay.cs
+++ b/Content.Server/_Stories/TTS/TTSSystem.Relay.cs
@@ -1,0 +1,41 @@
+using System.Threading.Tasks;
+using Content.Shared._Stories.TTS;
+using Robust.Shared.Player;
+
+namespace Content.Server._Stories.TTS;
+
+public sealed partial class TTSSystem
+{
+    public async Task PlayRelayedTTS(
+        EntityUid speaker,
+        string message,
+        Filter recipients,
+        EntityUid playbackSource,
+        TTSAudioEffect audioEffects,
+        bool isRadio)
+    {
+        if (message.Length > MaxMessageChars ||
+            message.Contains('\u200B') ||
+            !TryComp<TTSComponent>(speaker, out var tts) ||
+            !TryResolveVoiceForEntity(speaker, tts.VoicePrototypeId, out var voice))
+        {
+            return;
+        }
+
+        var soundData = await GenerateTTS(message, voice.Speaker);
+        if (soundData == null || !Exists(speaker) || !Exists(playbackSource))
+            return;
+
+        soundData = await ProcessTtsAudio(speaker, soundData, audioEffects);
+        if (!Exists(speaker) || !Exists(playbackSource))
+            return;
+
+        var ev = new PlayTTSEvent(
+            soundData,
+            message,
+            GetNetEntity(playbackSource),
+            originalSourceUid: GetNetEntity(speaker),
+            isRadio: isRadio);
+        RaiseNetworkEvent(ev, recipients);
+    }
+}

--- a/Content.Server/_Stories/TTS/TTSSystem.cs
+++ b/Content.Server/_Stories/TTS/TTSSystem.cs
@@ -202,21 +202,29 @@ public sealed partial class TTSSystem : EntitySystem
         return true;
     }
 
-    private void OnEntitySpoke(EntityUid uid, TTSComponent component, EntitySpokeEvent args)
+    private bool TryResolveVoiceForEntity(
+        EntityUid uid,
+        string? voiceId,
+        [NotNullWhen(true)] out TTSVoicePrototype? voicePrototype)
     {
-        var voiceId = component.VoicePrototypeId;
-        if (args.Message.Length > MaxMessageChars || voiceId == null)
-            return;
+        voicePrototype = null;
+        if (voiceId == null)
+            return false;
 
         var voiceEv = new TransformSpeakerVoiceEvent(uid, voiceId);
         RaiseLocalEvent(uid, voiceEv);
-        voiceId = voiceEv.VoiceId;
 
-        if (!GetVoicePrototype(voiceId, out var protoVoice) || !ValidateVoiceForEntity(uid, protoVoice))
-        {
-            if (!GetVoicePrototype("father_grigori", out protoVoice))
-                return;
-        }
+        if (GetVoicePrototype(voiceEv.VoiceId, out voicePrototype) && ValidateVoiceForEntity(uid, voicePrototype))
+            return true;
+
+        return GetVoicePrototype("father_grigori", out voicePrototype);
+    }
+
+    private void OnEntitySpoke(EntityUid uid, TTSComponent component, EntitySpokeEvent args)
+    {
+        if (args.Message.Length > MaxMessageChars ||
+            !TryResolveVoiceForEntity(uid, component.VoicePrototypeId, out var protoVoice))
+            return;
 
         var messageToUse = args.Message;
 


### PR DESCRIPTION
## Описание PR

Добавляет TTS для разговоров по RMC-телефонам. Голос воспроизводится из принимающей трубки только для игрока, который её держит. Старый фоновый звук болтовни отключён.

## Причина / Баланс

Делает телефонные разговоры понятнее и сохраняет приватность: окружающие принимающую трубку игроки телефонный TTS не слышат.

## Технические детали

Добавлена адресная отправка TTS с голосом говорящего, позиционным источником на принимающей трубке, поддержкой клиентского мута и радиоэффекта. Общая логика выбора голоса переиспользуется обычным и телефонным TTS.

## Медиа


https://github.com/user-attachments/assets/d3235dac-6bf5-4ed2-ac25-33a453c9c4a9



## Требования

- [x] Я прочитал(а) и следую [[Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html)](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [x] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение.
- [x] Я подтверждаю, что ознакомился(ась) с [[Space Stories License Agreement](https://github.com/MetalSage/space-stories-cm14/blob/master/LICENSE.TXT)](https://github.com/MetalSage/space-stories-cm14/blob/master/LICENSE.TXT) и полностью согласен(на) с его условиями.

**Changelog (Список изменений)**

:cl:GrigoriyGalintano
- add: Разговоры по телефонам теперь озвучиваются через TTS.
- remove: Убран фоновый звук болтовни при получении телефонного сообщения.