### PR TITLE
Возможность установки C4 на мобов

### DIFF
--- a/Content.Shared/_RMC14/Explosion/RMCC4DisarmableComponent.cs
+++ b/Content.Shared/_RMC14/Explosion/RMCC4DisarmableComponent.cs
@@ -1,0 +1,36 @@
+using Content.Shared._RMC14.Xenonids.Acid;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Explosion;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(RMCC4DisarmableSystem))]
+public sealed partial class RMCC4DisarmableComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan AcidDelay = TimeSpan.FromSeconds(4);
+
+    [DataField, AutoNetworkedField]
+    public XenoAcidStrength MinimumAcidStrength = XenoAcidStrength.Weak;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan MultitoolDelay = TimeSpan.FromSeconds(3);
+
+    [DataField, AutoNetworkedField]
+    public LocId AcidStartPopup = "rmc-c4-acid-start";
+
+    [DataField, AutoNetworkedField]
+    public LocId AcidFinishPopup = "rmc-c4-acid-finish";
+
+    [DataField, AutoNetworkedField]
+    public LocId AcidTooWeakPopup = "rmc-c4-acid-too-weak";
+
+    [DataField, AutoNetworkedField]
+    public LocId MultitoolStartPopup = "rmc-c4-disarm-start";
+
+    [DataField, AutoNetworkedField]
+    public LocId MultitoolStopPopup = "rmc-c4-disarm-stop";
+
+    [DataField, AutoNetworkedField]
+    public LocId MultitoolFinishPopup = "rmc-c4-disarm-finish";
+}

--- a/Content.Shared/_RMC14/Explosion/RMCC4DisarmableSystem.cs
+++ b/Content.Shared/_RMC14/Explosion/RMCC4DisarmableSystem.cs
@@ -1,0 +1,361 @@
+using Content.Shared._RMC14.Tools;
+using Content.Shared._RMC14.Xenonids.Acid;
+using Content.Shared._RMC14.Xenonids.Energy;
+using Content.Shared._RMC14.Xenonids.Plasma;
+using Content.Shared.DoAfter;
+using Content.Shared.Explosion.Components;
+using Content.Shared.FixedPoint;
+using Content.Shared.Interaction;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Popups;
+using Content.Shared.Sticky.Components;
+using Content.Shared.Sticky.Systems;
+using Content.Shared.Trigger;
+using Robust.Shared.Containers;
+using Robust.Shared.Network;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Explosion;
+
+public sealed class RMCC4DisarmableSystem : EntitySystem
+{
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly StickySystem _sticky = default!;
+    [Dependency] private readonly XenoEnergySystem _xenoEnergy = default!;
+    [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
+
+    private const string StickerSlotId = "stickers_container";
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<XenoAcidComponent, BeforeXenoCorrosiveAcidEvent>(OnXenoAcid);
+        SubscribeLocalEvent<XenoAcidComponent, DoAfterAttemptEvent<RMCC4AcidDoAfterEvent>>(OnC4AcidDoAfterAttempt);
+        SubscribeLocalEvent<XenoAcidComponent, RMCC4AcidDoAfterEvent>(OnC4AcidDoAfter);
+
+        SubscribeLocalEvent<RMCC4DisarmableComponent, InteractUsingEvent>(OnC4InteractUsing);
+        SubscribeLocalEvent<RMCC4DisarmableComponent, RMCC4MultitoolDisarmDoAfterEvent>(OnMultitoolDoAfter);
+        SubscribeLocalEvent<MobStateComponent, AccessibleOverrideEvent>(OnMobAccessibleOverride);
+        SubscribeLocalEvent<MobStateComponent, InRangeOverrideEvent>(OnMobInRangeOverride);
+        SubscribeLocalEvent<MobStateComponent, InteractUsingEvent>(OnMobInteractUsing);
+        SubscribeLocalEvent<RMCWallExplosionDeletableComponent, InteractUsingEvent>(OnWallInteractUsing);
+    }
+
+    private void OnXenoAcid(Entity<XenoAcidComponent> xeno, ref BeforeXenoCorrosiveAcidEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!TryGetC4(args.Target, out var c4))
+            return;
+
+        var acid = args.Acid;
+        if (acid.Strength < c4.Comp.MinimumAcidStrength)
+        {
+            args.Handled = true;
+            _popup.PopupClient(
+                Loc.GetString(c4.Comp.AcidTooWeakPopup, ("explosive", c4.Owner)),
+                args.Target,
+                xeno,
+                PopupType.SmallCaution);
+            return;
+        }
+
+        args.Handled = true;
+
+        var delay = c4.Comp.AcidDelay * acid.ApplyTimeMultiplier;
+        var doAfter = new DoAfterArgs(EntityManager,
+            xeno,
+            delay,
+            new RMCC4AcidDoAfterEvent(acid, GetNetEntity(c4.Owner)),
+            xeno,
+            args.Target)
+        {
+            BreakOnMove = true,
+            RequireCanInteract = false,
+            AttemptFrequency = AttemptFrequency.StartAndEnd,
+        };
+
+        if (_doAfter.TryStartDoAfter(doAfter))
+        {
+            _popup.PopupClient(
+                Loc.GetString(c4.Comp.AcidStartPopup, ("explosive", c4.Owner)),
+                args.Target,
+                xeno);
+        }
+    }
+
+    private void OnC4AcidDoAfterAttempt(Entity<XenoAcidComponent> xeno, ref DoAfterAttemptEvent<RMCC4AcidDoAfterEvent> args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (_mobState.IsIncapacitated(xeno))
+            args.Cancel();
+    }
+
+    private void OnC4AcidDoAfter(Entity<XenoAcidComponent> xeno, ref RMCC4AcidDoAfterEvent args)
+    {
+        if (args.Handled || args.Cancelled || args.Target is not { } target)
+            return;
+
+        if (!TryGetEntity(args.C4, out var c4Id) ||
+            TerminatingOrDeleted(c4Id.Value) ||
+            !TryComp(c4Id.Value, out RMCC4DisarmableComponent? disarmable) ||
+            !IsC4OnTarget(target, c4Id.Value) ||
+            disarmable.MinimumAcidStrength > args.Strength)
+        {
+            return;
+        }
+
+        Entity<RMCC4DisarmableComponent> c4 = (c4Id.Value, disarmable);
+
+        if (args.PlasmaCost != FixedPoint2.Zero && !_xenoPlasma.TryRemovePlasmaPopup(xeno.Owner, args.PlasmaCost))
+            return;
+
+        if (args.EnergyCost != 0 && !_xenoEnergy.TryRemoveEnergyPopup(xeno.Owner, args.EnergyCost))
+            return;
+
+        args.Handled = true;
+
+        if (_net.IsClient)
+            return;
+
+        _popup.PopupEntity(
+            Loc.GetString(c4.Comp.AcidFinishPopup, ("explosive", c4.Owner)),
+            target,
+            xeno);
+
+        StopTimer(c4.Owner);
+        QueueDel(c4.Owner);
+    }
+
+    private void OnC4InteractUsing(Entity<RMCC4DisarmableComponent> c4, ref InteractUsingEvent args)
+    {
+        TryStartMultitoolDisarm(c4, args.User, args.Used, GetDisarmTarget(c4.Owner), ref args);
+    }
+
+    private void OnMobAccessibleOverride(Entity<MobStateComponent> user, ref AccessibleOverrideEvent args)
+    {
+        if (args.Handled || !TryGetStickySurface(args.Target, out var surface))
+            return;
+
+        args.Handled = true;
+        args.Accessible = _interaction.IsAccessible((user.Owner, null), (surface, null));
+    }
+
+    private void OnMobInRangeOverride(Entity<MobStateComponent> user, ref InRangeOverrideEvent args)
+    {
+        if (args.Handled || !TryGetStickySurface(args.Target, out var surface))
+            return;
+
+        args.Handled = true;
+        args.InRange = _interaction.InRangeUnobstructed(user.Owner, surface);
+    }
+
+    private void OnMobInteractUsing(Entity<MobStateComponent> target, ref InteractUsingEvent args)
+    {
+        TryStartContainedMultitoolDisarm(target.Owner, ref args);
+    }
+
+    private void OnWallInteractUsing(Entity<RMCWallExplosionDeletableComponent> target, ref InteractUsingEvent args)
+    {
+        TryStartContainedMultitoolDisarm(target.Owner, ref args);
+    }
+
+    private void TryStartContainedMultitoolDisarm(EntityUid target, ref InteractUsingEvent args)
+    {
+        if (TryGetContainedC4(target, out var c4))
+            TryStartMultitoolDisarm(c4, args.User, args.Used, target, ref args);
+    }
+
+    private void TryStartMultitoolDisarm(
+        Entity<RMCC4DisarmableComponent> c4,
+        EntityUid user,
+        EntityUid used,
+        EntityUid target,
+        ref InteractUsingEvent args)
+    {
+        if (args.Handled || !HasComp<MultitoolComponent>(used))
+            return;
+
+        if (!HasComp<ActiveTimerTriggerComponent>(c4.Owner))
+            return;
+
+        if (!IsC4OnTarget(target, c4.Owner))
+            return;
+
+        args.Handled = true;
+
+        var doAfter = new DoAfterArgs(EntityManager,
+            user,
+            c4.Comp.MultitoolDelay,
+            new RMCC4MultitoolDisarmDoAfterEvent(),
+            c4.Owner,
+            target,
+            used)
+        {
+            BreakOnMove = true,
+            BreakOnDamage = true,
+            NeedHand = true,
+            AttemptFrequency = AttemptFrequency.StartAndEnd,
+        };
+
+        if (_doAfter.TryStartDoAfter(doAfter))
+        {
+            _popup.PopupClient(
+                Loc.GetString(c4.Comp.MultitoolStartPopup, ("explosive", c4.Owner)),
+                target,
+                user);
+        }
+    }
+
+    private void OnMultitoolDoAfter(Entity<RMCC4DisarmableComponent> c4, ref RMCC4MultitoolDisarmDoAfterEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        args.Handled = true;
+
+        if (args.Cancelled)
+        {
+            _popup.PopupClient(
+                Loc.GetString(c4.Comp.MultitoolStopPopup, ("explosive", c4.Owner)),
+                args.Target ?? c4.Owner,
+                args.User);
+            return;
+        }
+
+        if (!HasComp<ActiveTimerTriggerComponent>(c4.Owner))
+            return;
+
+        if (args.Target is { } target && !IsC4OnTarget(target, c4.Owner))
+            return;
+
+        StopTimer(c4.Owner);
+
+        if (TryComp(c4.Owner, out StickyComponent? sticky))
+            _sticky.UnstickFromEntity((c4.Owner, sticky), args.User);
+
+        _popup.PopupClient(
+            Loc.GetString(c4.Comp.MultitoolFinishPopup, ("explosive", c4.Owner)),
+            args.Target ?? c4.Owner,
+            args.User);
+    }
+
+    private EntityUid GetDisarmTarget(EntityUid c4)
+    {
+        return TryGetStickySurface(c4, out var surface) ? surface : c4;
+    }
+
+    private bool TryGetStickySurface(EntityUid c4, out EntityUid surface)
+    {
+        surface = default;
+
+        if (!HasComp<RMCC4DisarmableComponent>(c4) ||
+            !TryComp(c4, out StickyComponent? sticky) ||
+            sticky.StuckTo is not { } stuckTo ||
+            TerminatingOrDeleted(stuckTo))
+        {
+            return false;
+        }
+
+        surface = stuckTo;
+        return true;
+    }
+
+    private bool TryGetC4(EntityUid target, out Entity<RMCC4DisarmableComponent> c4)
+    {
+        if (TryComp(target, out RMCC4DisarmableComponent? direct))
+        {
+            c4 = (target, direct);
+            return true;
+        }
+
+        return TryGetContainedC4(target, out c4);
+    }
+
+    private bool TryGetContainedC4(EntityUid target, out Entity<RMCC4DisarmableComponent> c4)
+    {
+        if (!_container.TryGetContainer(target, StickerSlotId, out var container))
+        {
+            c4 = default;
+            return false;
+        }
+
+        foreach (var contained in container.ContainedEntities)
+        {
+            if (!TryComp(contained, out RMCC4DisarmableComponent? disarmable))
+                continue;
+
+            c4 = (contained, disarmable);
+            return true;
+        }
+
+        c4 = default;
+        return false;
+    }
+
+    private bool IsC4OnTarget(EntityUid target, EntityUid c4)
+    {
+        if (target == c4)
+            return true;
+
+        if (!_container.TryGetContainer(target, StickerSlotId, out var container))
+            return false;
+
+        foreach (var contained in container.ContainedEntities)
+        {
+            if (contained == c4)
+                return true;
+        }
+
+        return false;
+    }
+
+    private void StopTimer(EntityUid uid)
+    {
+        RemComp<ActiveTimerTriggerComponent>(uid);
+
+        if (TryComp(uid, out AppearanceComponent? appearance))
+            _appearance.SetData(uid, TriggerVisuals.VisualState, TriggerVisualState.Unprimed, appearance);
+    }
+}
+
+[Serializable, NetSerializable]
+public sealed partial class RMCC4AcidDoAfterEvent : DoAfterEvent
+{
+    [DataField]
+    public NetEntity C4;
+
+    [DataField]
+    public XenoAcidStrength Strength = XenoAcidStrength.Normal;
+
+    [DataField]
+    public FixedPoint2 PlasmaCost = 100;
+
+    [DataField]
+    public int EnergyCost;
+
+    public RMCC4AcidDoAfterEvent(XenoCorrosiveAcidEvent ev, NetEntity c4)
+    {
+        C4 = c4;
+        Strength = ev.Strength;
+        PlasmaCost = ev.PlasmaCost;
+        EnergyCost = ev.EnergyCost;
+    }
+
+    public override DoAfterEvent Clone()
+    {
+        return this;
+    }
+}
+
+[Serializable, NetSerializable]
+public sealed partial class RMCC4MultitoolDisarmDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/_RMC14/Explosion/RMCPreventSameFactionStickComponent.cs
+++ b/Content.Shared/_RMC14/Explosion/RMCPreventSameFactionStickComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Explosion;
+
+[RegisterComponent, NetworkedComponent, Access(typeof(RMCPreventSameFactionStickSystem))]
+public sealed partial class RMCPreventSameFactionStickComponent : Component
+{
+    [DataField]
+    public LocId Popup = "rmc-explosive-cannot-stick-same-faction";
+}

--- a/Content.Shared/_RMC14/Explosion/RMCPreventSameFactionStickSystem.cs
+++ b/Content.Shared/_RMC14/Explosion/RMCPreventSameFactionStickSystem.cs
@@ -1,0 +1,58 @@
+using Content.Shared._RMC14.Weapons.Ranged.IFF;
+using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared.Inventory;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Popups;
+using Content.Shared.Sticky;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Explosion;
+
+public sealed class RMCPreventSameFactionStickSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedXenoHiveSystem _xenoHive = default!;
+
+    private readonly HashSet<EntProtoId<IFFFactionComponent>> _targetFactions = new();
+    private readonly HashSet<EntProtoId<IFFFactionComponent>> _userFactions = new();
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<RMCPreventSameFactionStickComponent, AttemptEntityStickEvent>(OnAttemptStick);
+    }
+
+    private void OnAttemptStick(Entity<RMCPreventSameFactionStickComponent> ent, ref AttemptEntityStickEvent args)
+    {
+        if (args.Cancelled || !HasComp<MobStateComponent>(args.Target))
+            return;
+
+        if (!IsSameFaction(args.User, args.Target))
+            return;
+
+        args.Cancelled = true;
+        _popup.PopupClient(Loc.GetString(ent.Comp.Popup), args.User, args.User, PopupType.MediumCaution);
+    }
+
+    private bool IsSameFaction(EntityUid user, EntityUid target)
+    {
+        if (_xenoHive.FromSameHive(user, target))
+            return true;
+
+        if (HasComp<HiveMemberComponent>(user) || HasComp<HiveMemberComponent>(target))
+            return false;
+
+        _userFactions.Clear();
+        _targetFactions.Clear();
+
+        var userFactionEvent = new GetIFFFactionEvent(SlotFlags.IDCARD, _userFactions);
+        RaiseLocalEvent(user, ref userFactionEvent);
+
+        if (_userFactions.Count == 0)
+            return false;
+
+        var targetFactionEvent = new GetIFFFactionEvent(SlotFlags.IDCARD, _targetFactions);
+        RaiseLocalEvent(target, ref targetFactionEvent);
+
+        return _targetFactions.Count != 0 && _userFactions.Overlaps(_targetFactions);
+    }
+}

--- a/Content.Shared/_RMC14/Xenonids/Acid/SharedXenoAcidSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Acid/SharedXenoAcidSystem.cs
@@ -137,8 +137,20 @@ public abstract class SharedXenoAcidSystem : EntitySystem
             }
         }
 
-        if (xeno.Owner != args.Performer ||
-            !CheckCorrodiblePopupsWithReplacement(xeno, target, args.Strength, out var time, out var _))
+        if (xeno.Owner != args.Performer)
+            return;
+
+        var attempt = new BeforeXenoCorrosiveAcidEvent(args, target);
+        RaiseLocalEvent(xeno.Owner, ref attempt);
+        if (attempt.Handled)
+        {
+            args.Handled = true;
+            return;
+        }
+
+        target = attempt.Target;
+
+        if (!CheckCorrodiblePopupsWithReplacement(xeno, target, args.Strength, out var time, out var _))
         {
             return;
         }
@@ -600,4 +612,10 @@ public abstract class SharedXenoAcidSystem : EntitySystem
         corrodible.IsCorrodible = isCorrodible;
         Dirty(entity, corrodible);
     }
+}
+
+[ByRefEvent]
+public record struct BeforeXenoCorrosiveAcidEvent(XenoCorrosiveAcidEvent Acid, EntityUid Target)
+{
+    public bool Handled;
 }

--- a/Resources/Locale/en-US/_RMC14/weapons/explosives.ftl
+++ b/Resources/Locale/en-US/_RMC14/weapons/explosives.ftl
@@ -1,2 +1,9 @@
 rmc-mine-deploy-fail-occupied = There already is a mine at this position!
 rmc-explosive-deploy-container = It's too cramped in here to deploy the {$explosive}
+rmc-explosive-cannot-stick-same-faction = ARE YOU OUT OF YOUR MIND?!
+rmc-c4-acid-start = You start dissolving {$explosive} with acid.
+rmc-c4-acid-finish = You dissolve {$explosive} with acid.
+rmc-c4-acid-too-weak = Your acid is too weak to dissolve {$explosive}.
+rmc-c4-disarm-start = You start disarming {$explosive}.
+rmc-c4-disarm-stop = You stop disarming {$explosive}.
+rmc-c4-disarm-finish = You finish disarming {$explosive}.

--- a/Resources/Locale/ru-RU/_RMC14/weapons/explosives.ftl
+++ b/Resources/Locale/ru-RU/_RMC14/weapons/explosives.ftl
@@ -1,2 +1,9 @@
 rmc-mine-deploy-fail-occupied = На этом месте уже находится мина!
 rmc-explosive-deploy-container = Здесь слишком тесно, чтобы установить { $explosive }
+rmc-explosive-cannot-stick-same-faction = ТЫ С УМА СОШЁЛ?!
+rmc-c4-acid-start = Вы начинаете растворять { $explosive } кислотой.
+rmc-c4-acid-finish = Вы растворяете { $explosive } кислотой.
+rmc-c4-acid-too-weak = Ваша кислота слишком слаба, чтобы растворить { $explosive }.
+rmc-c4-disarm-start = Вы начинаете обезвреживать { $explosive }.
+rmc-c4-disarm-stop = Вы прекращаете обезвреживать { $explosive }.
+rmc-c4-disarm-finish = Вы обезвреживаете { $explosive }.

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Explosives/breaching_charge.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Explosives/breaching_charge.yml
@@ -91,6 +91,7 @@
       components:
       - RMCWallExplosionDeletable
       - XenoTunnel
+      - MobState
   - type: RMCExplosiveDelete
     delay: 10
     beepSound:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Explosives/breaching_charge.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Explosives/breaching_charge.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: BaseItem
   id: RMCExplosiveBreachingCharge
-  name: breaching charge # TODO RMC14 disable with multitool?
+  name: breaching charge
   description: An explosive device used to break into areas while protecting the user from the blast as well as deploying deadly shrapnel on the other side.
   components:
   - type: Sprite
@@ -22,6 +22,8 @@
     whitelist:
       components:
       - RMCWallExplosionDeletable
+  - type: RMCC4Disarmable
+    multitoolDelay: 2.5
   - type: Explosive
     explosionType: RMC
     totalIntensity: 1
@@ -92,6 +94,9 @@
       - RMCWallExplosionDeletable
       - XenoTunnel
       - MobState
+  - type: RMCPreventSameFactionStick
+  - type: RMCC4Disarmable
+    multitoolDelay: 3
   - type: RMCExplosiveDelete
     delay: 10
     beepSound:


### PR DESCRIPTION
<!-- Руководство: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR

Теперь пластичную взрывчатку можно устанавливать на мобов, включая ксеноморфов, используя существующую механику липкой взрывчатки.

Также добавлены ограничения и способы противодействия установленной взрывчатке:

- пластичную взрывчатку нельзя устанавливать на мобов своей фракции;
- ксеноморфы могут растворять установленную C4 кислотой;
- активную пластичную взрывчатку и пробивные заряды можно обезвредить мультитулом.

## Причина / Баланс

Изменение приближает поведение пластичной взрывчатки к CM13, где C4 можно устанавливать непосредственно на мобов.

Сохраняются существующие параметры пластичной взрывчатки: 5-секундный do-after установки и 10-секундный таймер детонации. Таким образом, установка C4 на моба требует времени и может быть прервана.

Чтобы предотвратить злоупотребления, C4 нельзя прикреплять к целям своей фракции. Для определения фракции используются существующие системы RMC hive/IFF, а не статические проверки, поэтому изменения улья, фракции или IFF во время раунда учитываются корректно.

Также добавлены способы противодействия:

- ксеноморфы могут удалить установленную C4 кислотой;
- инженеры могут обезвредить активную пластичную взрывчатку и пробивные заряды с помощью мультитула.

Пробивные заряды по-прежнему нельзя устанавливать на мобов.

## Технические детали

Whitelist компонента `Sticky` для `RMCExplosivePlastic` расширен и теперь включает `MobState`.

Добавлен `RMCPreventSameFactionStickComponent` и системная логика, запрещающая прикреплять взрывчатку к мобам своей фракции. Проверка использует существующие события RMC hive и IFF, поэтому изменения фракции или ID во время игры корректно учитываются.

Добавлен `RMCC4DisarmableComponent` и общая логика обезвреживания активной C4-подобной взрывчатки:

- кислота ксеноморфов может растворять установленную C4;
- мультитулом можно обезвредить активную пластичную взрывчатку и пробивные заряды;
- обезвреживание работает как при нажатии непосредственно на заряд, так и на моба или стену, к которым он прикреплён;
- для прикреплённых зарядов переопределяются проверки доступности и дистанции, чтобы заряд не становился недоступным после попадания внутрь `Contents` цели.

Существующий `StickySystem` по-прежнему отвечает за do-after установки и прикрепление заряда.

Существующий `RMCExplosionSystem` по-прежнему запускает таймер через `EntityStuckEvent`.

`RMCExplosiveDelete` не был расширен на мобов, поэтому установленная пластичная взрывчатка не удаляет цель напрямую. Она детонирует обычным образом через существующую систему взрывов.

## Медиа

Не требуется.

## Требования

- [x] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [x] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение. Я беру на себя полную ответственность за любые юридические претензии или проблемы, возникающие из-за использования этих материалов.
- [x] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](https://github.com/MetalSage/space-stories-cm14/blob/master/LICENSE.TXT) и полностью согласен(на) с его условиями. В частности, я предоставляю Лицензиару бессрочную, безвозмездную, неисключительную и безотзывную лицензию на использование, модификацию и распространение моего вклада.

**Changelog (Список изменений)**

:cl:GrigoriyGalintano
- tweak: Пластичную взрывчатку теперь можно устанавливать на мобов.
- add: Активную пластичную взрывчатку и пробивные заряды теперь можно обезвредить мультитулом.
- add: Ксеноморфы теперь могут растворять установленную C4 кислотой.