### PR TITLE
Исправление ​​ошибки сброса состояния окна телепортации призрака

### DIFF
--- a/Content.Client/_RMC14/UserInterface/Systems/Ghost/Controls/RMCGhostTargetWindow.xaml.cs
+++ b/Content.Client/_RMC14/UserInterface/Systems/Ghost/Controls/RMCGhostTargetWindow.xaml.cs
@@ -76,6 +76,7 @@ public sealed partial class RMCGhostTargetWindow : DefaultWindow
 
     public void ClearContent()
     {
+        SearchBar.SetText(string.Empty, true);
         _ghostnadoHovered = false;
         _ghostnadoPressed = false;
         _targets.Clear();

--- a/Content.Client/_RMC14/UserInterface/Systems/Ghost/RMCGhostTargetRequestState.cs
+++ b/Content.Client/_RMC14/UserInterface/Systems/Ghost/RMCGhostTargetRequestState.cs
@@ -34,8 +34,9 @@ internal sealed class RMCGhostTargetRequestState
         return true;
     }
 
-    public void CancelQueued()
+    public void Reset()
     {
+        _pendingRequestId = null;
         _refreshQueued = false;
     }
 }

--- a/Content.Client/_RMC14/UserInterface/Systems/Ghost/RMCGhostTargetUIController.cs
+++ b/Content.Client/_RMC14/UserInterface/Systems/Ghost/RMCGhostTargetUIController.cs
@@ -1,5 +1,6 @@
 using Content.Client._RMC14.UserInterface.Systems.Ghost.Controls;
 using Content.Shared._RMC14.Ghost;
+using Content.Shared.GameTicking;
 using Content.Shared.Ghost;
 using Robust.Client.UserInterface.Controllers;
 using Robust.Shared.Player;
@@ -19,6 +20,7 @@ public sealed class RMCGhostTargetUIController : UIController, IOnSystemChanged<
         base.Initialize();
 
         SubscribeNetworkEvent<RMCGhostWarpsResponseEvent>(OnGhostWarpsResponse);
+        SubscribeNetworkEvent<RoundRestartCleanupEvent>(OnRoundRestartCleanup);
     }
 
     public void OnSystemLoaded(ClientGhostSystem system)
@@ -63,6 +65,22 @@ public sealed class RMCGhostTargetUIController : UIController, IOnSystemChanged<
         _net.SendSystemNetworkMessage(new RMCGhostWarpToTargetRequestEvent(target));
     }
 
+    private void OnRefreshClicked()
+    {
+        _requests.Reset();
+        RequestWarps();
+    }
+
+    private void OnRoundRestartCleanup(RoundRestartCleanupEvent msg, EntitySessionEventArgs args)
+    {
+        CloseWindow();
+    }
+
+    private void OnWindowClosed()
+    {
+        _requests.Reset();
+    }
+
     private void RequestWarps()
     {
         if (_requests.Request() is not { } requestId)
@@ -78,7 +96,7 @@ public sealed class RMCGhostTargetUIController : UIController, IOnSystemChanged<
 
     private void CloseWindow()
     {
-        _requests.CancelQueued();
+        _requests.Reset();
         _window?.Close();
     }
 
@@ -89,7 +107,8 @@ public sealed class RMCGhostTargetUIController : UIController, IOnSystemChanged<
 
         _window = new RMCGhostTargetWindow();
         _window.WarpClicked += OnWarpClicked;
-        _window.OnRefreshClicked += RequestWarps;
+        _window.OnRefreshClicked += OnRefreshClicked;
+        _window.OnClose += OnWindowClosed;
         return _window;
     }
 }


### PR DESCRIPTION
## Описание PR

Исправлен сброс состояния окна телепортации призрака при закрытии, обновлении и перезапуске раунда.

## Причина / Баланс

Устраняет зависание запросов и сохранение старого состояния окна. На игровой баланс не влияет.

## Технические детали

- Сбрасывается состояние активного запроса.
- Очищается строка поиска при закрытии окна.
- Окно закрывается при перезапуске раунда.
- Кнопка обновления запрашивает актуальные данные.

## Медиа

Не требуется 

## Требования

- [x] Я прочитал(а) и следую [Руководству по Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы в этот PR, либо он не требует внутриигровой демонстрации.
- [x] Отправляя этот код и/или ассеты, я подтверждаю, что являюсь их автором, либо предоставил(а) необходимые корректные лицензии на их использование и распространение.
- [x] Я подтверждаю, что ознакомился(ась) с [Space Stories License Agreement](https://github.com/MetalSage/space-stories-cm14/blob/master/LICENSE.TXT) и полностью согласен(на) с его условиями.

**Changelog (Список изменений)**

:cl:GrigoriyGalintano
- fix: Исправлен сброс состояния окна телепортации призрака.